### PR TITLE
feat: align python sdk with ksef docs 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SDK zostało zaprojektowane w oparciu o oficjalne biblioteki referencyjne KSeF d
 
 ## 🔄 Kompatybilność API KSeF
 
-Aktualna kompatybilność: **KSeF API `v2.1.1`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.1.1/api-changelog.md)).
+Aktualna kompatybilność: **KSeF API `v2.1.2`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.1.2/api-changelog.md)).
 
 ## ✅ Funkcjonalności
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Dokumentacja opisuje **publiczne API** biblioteki `ksef-client-python` (import: 
 
 Opis kontraktu API (OpenAPI) oraz dokumenty procesowe i ograniczenia systemu znajdują się w `ksef-docs/`.
 
-Kompatybilność SDK: **KSeF API `v2.1.1`**.
+Kompatybilność SDK: **KSeF API `v2.1.2`**.
 
 ## Wymagania
 

--- a/docs/api/invoices.md
+++ b/docs/api/invoices.md
@@ -22,6 +22,10 @@ Endpoint służy do wyszukiwania metadanych faktur. `request_payload` zależy od
 
 Typowe zastosowanie: synchronizacja historii metadanych i późniejsze pobieranie treści XML po `ksefNumber`.
 
+Uwaga dla `dateRange`:
+- jeśli `dateRange.from` / `dateRange.to` jest podane jako ISO date-time bez offsetu (`YYYY-MM-DDTHH:MM[:SS]`),
+  SDK normalizuje je do strefy `Europe/Warsaw` i wysyła z jawnie dopisanym offsetem (`+01:00`/`+02:00`).
+
 ## `export_invoices(request_payload, access_token)`
 
 Endpoint: `POST /invoices/exports`
@@ -32,6 +36,9 @@ Wymagane minimum w `request_payload`:
 - `encryption.encryptedSymmetricKey`
 - `encryption.initializationVector`
 - `filters` (np. `subjectType` + `dateRange`)
+
+Uwaga dla `filters.dateRange`:
+- ISO date-time bez offsetu jest normalizowany do `Europe/Warsaw` przed wysyłką requestu.
 
 ## `get_export_status(reference_number, access_token)`
 

--- a/src/ksef_client/clients/invoices.py
+++ b/src/ksef_client/clients/invoices.py
@@ -1,9 +1,65 @@
 from __future__ import annotations
 
+import re
+from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from ..models import BinaryContent, InvoiceContent
 from .base import AsyncBaseApiClient, BaseApiClient
+
+_OFFSET_SUFFIX_RE = re.compile(r"(?:Z|[+-]\d{2}:?\d{2})$")
+
+
+def _last_sunday_of_month(year: int, month: int) -> int:
+    cursor = date(year, 12, 31) if month == 12 else date(year, month + 1, 1) - timedelta(days=1)
+    while cursor.weekday() != 6:  # Sunday
+        cursor -= timedelta(days=1)
+    return cursor.day
+
+
+def _warsaw_offset_for_local_datetime(local_dt: datetime) -> timedelta:
+    year = local_dt.year
+    dst_start = datetime(year, 3, _last_sunday_of_month(year, 3), 2, 0, 0)
+    dst_end = datetime(year, 10, _last_sunday_of_month(year, 10), 3, 0, 0)
+    if dst_start <= local_dt < dst_end:
+        return timedelta(hours=2)
+    return timedelta(hours=1)
+
+
+def _normalize_datetime_without_offset(value: str) -> str:
+    if "T" not in value or _OFFSET_SUFFIX_RE.search(value):
+        return value
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+    if parsed.tzinfo is not None:
+        return value
+    offset = _warsaw_offset_for_local_datetime(parsed)
+    return parsed.replace(tzinfo=timezone(offset)).isoformat()
+
+
+def _normalize_invoice_date_range_payload(request_payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(request_payload)
+    date_range_candidates: list[dict[str, Any]] = []
+
+    top_level = normalized.get("dateRange")
+    if isinstance(top_level, dict):
+        date_range_candidates.append(top_level)
+
+    filters = normalized.get("filters")
+    if isinstance(filters, dict):
+        nested = filters.get("dateRange")
+        if isinstance(nested, dict):
+            date_range_candidates.append(nested)
+
+    for date_range in date_range_candidates:
+        for field_name in ("from", "to"):
+            value = date_range.get(field_name)
+            if isinstance(value, str):
+                date_range[field_name] = _normalize_datetime_without_offset(value)
+    return normalized
 
 
 class InvoicesClient(BaseApiClient):
@@ -39,6 +95,7 @@ class InvoicesClient(BaseApiClient):
         page_size: int | None = None,
         sort_order: str | None = None,
     ) -> Any:
+        normalized_payload = _normalize_invoice_date_range_payload(request_payload)
         params: dict[str, Any] = {}
         if page_offset is not None:
             params["pageOffset"] = page_offset
@@ -50,15 +107,16 @@ class InvoicesClient(BaseApiClient):
             "POST",
             "/invoices/query/metadata",
             params=params or None,
-            json=request_payload,
+            json=normalized_payload,
             access_token=access_token,
         )
 
     def export_invoices(self, request_payload: dict[str, Any], *, access_token: str) -> Any:
+        normalized_payload = _normalize_invoice_date_range_payload(request_payload)
         return self._request_json(
             "POST",
             "/invoices/exports",
-            json=request_payload,
+            json=normalized_payload,
             access_token=access_token,
             expected_status={201, 202},
         )
@@ -119,6 +177,7 @@ class AsyncInvoicesClient(AsyncBaseApiClient):
         page_size: int | None = None,
         sort_order: str | None = None,
     ) -> Any:
+        normalized_payload = _normalize_invoice_date_range_payload(request_payload)
         params: dict[str, Any] = {}
         if page_offset is not None:
             params["pageOffset"] = page_offset
@@ -130,15 +189,16 @@ class AsyncInvoicesClient(AsyncBaseApiClient):
             "POST",
             "/invoices/query/metadata",
             params=params or None,
-            json=request_payload,
+            json=normalized_payload,
             access_token=access_token,
         )
 
     async def export_invoices(self, request_payload: dict[str, Any], *, access_token: str) -> Any:
+        normalized_payload = _normalize_invoice_date_range_payload(request_payload)
         return await self._request_json(
             "POST",
             "/invoices/exports",
-            json=request_payload,
+            json=normalized_payload,
             access_token=access_token,
             expected_status={201, 202},
         )

--- a/src/ksef_client/openapi_models.py
+++ b/src/ksef_client/openapi_models.py
@@ -671,6 +671,7 @@ class TokenPermissionType(Enum):
     CREDENTIALSMANAGE = "CredentialsManage"
     SUBUNITMANAGE = "SubunitManage"
     ENFORCEMENTOPERATIONS = "EnforcementOperations"
+    INTROSPECTION = "Introspection"
 
 Challenge: TypeAlias = str
 
@@ -1291,7 +1292,7 @@ class InvoiceStatusInfo(OpenApiModel):
     code: int
     description: str
     details: Optional[list[str]] = None
-    extensions: Optional[dict[str, Optional[str]]] = None
+    extensions: Optional[dict[str, Any]] = None
 
 @dataclass(frozen=True)
 class OnlineSessionContextLimitsOverride(OpenApiModel):
@@ -1329,7 +1330,7 @@ class OpenOnlineSessionResponse(OpenApiModel):
 
 @dataclass(frozen=True)
 class PartUploadRequest(OpenApiModel):
-    headers: dict[str, Optional[str]]
+    headers: dict[str, Any]
     method: str
     ordinalNumber: int
     url: str


### PR DESCRIPTION
## Cel
Dostosowanie `ksef-client-python` do zmian opisanych w `ksef-docs` **2.1.2**.

## Zmiany względem docs 2.1.2
- **Wysyłka RR**: utrzymanie zgodności modeli OpenAPI i przepływów sesji z nowym zakresem formularzy (RR jest wspierane przez payload/formCode przekazywane do API).
- **Token `Introspection`**: `TokenPermissionType` został zaktualizowany i obejmuje `Introspection`.
- **`dateRange` bez offsetu**: dla `POST /invoices/query/metadata` i `POST /invoices/exports` datetime bez strefy jest normalizowany do `Europe/Warsaw` i wysyłany z offsetem.
- **OpenAPI forward-compat**: modele odzwierciedlają uelastycznienie kontraktu (`additionalProperties`), w tym testy dla pól rozszerzeń.

## Testy
- `python tools/lint.py --strict`
- `python -m pytest` (137 passed, 4 skipped)
- `python tools/check_coverage.py --openapi ../ksef-docs/open-api.json --src src/ksef_client/clients` (77/77)