### PR TITLE
chore(ci): dedupe repeated release-please changelog entries

### DIFF
--- a/.github/workflows/release-please-dedupe.yml
+++ b/.github/workflows/release-please-dedupe.yml
@@ -1,0 +1,61 @@
+name: Release Please Dedupe
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  dedupe-changelog:
+    if: startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dedupe repeated changelog bullets
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const originalBody = pr.body || "";
+            if (!originalBody.includes("### ")) {
+              return;
+            }
+
+            const lines = originalBody.split(/\r?\n/);
+            const seen = new Set();
+            const deduped = [];
+
+            const normalizeBullet = (line) =>
+              line
+                .replace(
+                  /\(\[[0-9a-f]{7}\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]{40}\)\)/gi,
+                  ""
+                )
+                .replace(/\s+/g, " ")
+                .trim()
+                .toLowerCase();
+
+            for (const line of lines) {
+              if (line.trim().startsWith("* ")) {
+                const key = normalizeBullet(line);
+                if (seen.has(key)) {
+                  continue;
+                }
+                seen.add(key);
+              }
+              deduped.push(line);
+            }
+
+            const updatedBody = deduped.join("\n");
+            if (updatedBody === originalBody) {
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              body: updatedBody,
+            });


### PR DESCRIPTION
## Problem
Release Please może dodać powtarzające się pozycje w changelogu PR release (np. identyczny wpis `Features` z różnymi hashami commitów).

## Rozwiązanie
Dodany workflow `release-please-dedupe.yml`, który uruchamia się na `pull_request_target` dla gałęzi `release-please--*` i automatycznie usuwa zduplikowane linie bullet (`* ...`) po normalizacji treści.

## Efekt
- bieżący przypadek zduplikowanego wpisu został uporządkowany,
- kolejne PR-y release będą automatycznie czyszczone z takich duplikatów.