### PR TITLE
feat(api): align SDK with KSeF API 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Projekt odwzorowuje oficjalne przepływy KSeF i zapewnia spójny model pracy w d
 
 ## 🔄 Kompatybilność
 
-Aktualna kompatybilność: **KSeF API `v2.1.2`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.1.2/api-changelog.md)).
+Aktualna kompatybilność: **KSeF API `v2.2.0`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.2.0/api-changelog.md)).
 
 ## 🧭 Spis treści
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Dokumentacja opisuje **publiczne API** biblioteki `ksef-client-python` (import: 
 
 Opis kontraktu API (OpenAPI) oraz dokumenty procesowe i ograniczenia systemu znajdują się w `ksef-docs/`.
 
-Kompatybilność SDK: **KSeF API `v2.1.2`**.
+Kompatybilność SDK: **KSeF API `v2.2.0`**.
 
 ## Wymagania
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -32,6 +32,7 @@ Endpoint: `POST /auth/challenge` (bez `accessToken`).
 
 Zwraca JSON z polami m.in.:
 - `challenge`
+- `clientIp`
 - `timestamp`
 - `timestampMs`
 

--- a/docs/api/permissions.md
+++ b/docs/api/permissions.md
@@ -59,6 +59,9 @@ Endpoint: `POST /permissions/query/authorizations/grants`
 ### `query_entities_roles(..., access_token)`
 Endpoint: `GET /permissions/query/entities/roles`
 
+### `query_entities_grants(request_payload, ..., access_token)`
+Endpoint: `POST /permissions/query/entities/grants`
+
 ### `query_eu_entities_grants(request_payload, ..., access_token)`
 Endpoint: `POST /permissions/query/eu-entities/grants`
 

--- a/src/ksef_client/clients/permissions.py
+++ b/src/ksef_client/clients/permissions.py
@@ -140,6 +140,23 @@ class PermissionsClient(BaseApiClient):
             access_token=access_token,
         )
 
+    def query_entities_grants(
+        self,
+        request_payload: dict[str, Any],
+        *,
+        page_offset: int | None = None,
+        page_size: int | None = None,
+        access_token: str,
+    ) -> Any:
+        params = _page_params(page_offset, page_size)
+        return self._request_json(
+            "POST",
+            "/permissions/query/entities/grants",
+            params=params or None,
+            json=request_payload,
+            access_token=access_token,
+        )
+
     def query_eu_entities_grants(
         self,
         request_payload: dict[str, Any],
@@ -353,6 +370,23 @@ class AsyncPermissionsClient(AsyncBaseApiClient):
             "GET",
             "/permissions/query/entities/roles",
             params=params or None,
+            access_token=access_token,
+        )
+
+    async def query_entities_grants(
+        self,
+        request_payload: dict[str, Any],
+        *,
+        page_offset: int | None = None,
+        page_size: int | None = None,
+        access_token: str,
+    ) -> Any:
+        params = _page_params(page_offset, page_size)
+        return await self._request_json(
+            "POST",
+            "/permissions/query/entities/grants",
+            params=params or None,
+            json=request_payload,
             access_token=access_token,
         )
 

--- a/src/ksef_client/http.py
+++ b/src/ksef_client/http.py
@@ -23,6 +23,11 @@ def _is_absolute_http_url(url: str) -> bool:
     return url.startswith("http://") or url.startswith("https://")
 
 
+def _is_json_content_type(content_type: str) -> bool:
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type == "application/json" or media_type.endswith("+json")
+
+
 def _host_allowed(host: str, allowed_hosts: list[str]) -> bool:
     normalized_host = host.lower().rstrip(".")
     for allowed in allowed_hosts:
@@ -177,7 +182,7 @@ class BaseHttpClient:
         retry_after = response.headers.get("Retry-After")
         content_type = response.headers.get("Content-Type", "")
         body: Any = None
-        if "application/json" in content_type:
+        if _is_json_content_type(content_type):
             try:
                 body = response.json()
             except ValueError:
@@ -285,7 +290,7 @@ class AsyncBaseHttpClient:
         retry_after = response.headers.get("Retry-After")
         content_type = response.headers.get("Content-Type", "")
         body: Any = None
-        if "application/json" in content_type:
+        if _is_json_content_type(content_type):
             try:
                 body = response.json()
             except ValueError:

--- a/src/ksef_client/models.py
+++ b/src/ksef_client/models.py
@@ -62,13 +62,16 @@ class AuthenticationChallengeResponse:
     challenge: str
     timestamp: str
     timestamp_ms: int
+    client_ip: str | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> AuthenticationChallengeResponse:
+        raw_client_ip = data.get("clientIp")
         return AuthenticationChallengeResponse(
             challenge=str(data.get("challenge", "")),
             timestamp=str(data.get("timestamp", "")),
             timestamp_ms=int(data.get("timestampMs", 0)),
+            client_ip=str(raw_client_ip) if raw_client_ip is not None else None,
         )
 
 

--- a/src/ksef_client/openapi_models.py
+++ b/src/ksef_client/openapi_models.py
@@ -348,9 +348,17 @@ class EntityAuthorizationsAuthorizedEntityIdentifierType(Enum):
 class EntityAuthorizationsAuthorizingEntityIdentifierType(Enum):
     NIP = "Nip"
 
+class EntityPermissionItemScope(Enum):
+    INVOICEWRITE = "InvoiceWrite"
+    INVOICEREAD = "InvoiceRead"
+
 class EntityPermissionType(Enum):
     INVOICEWRITE = "InvoiceWrite"
     INVOICEREAD = "InvoiceRead"
+
+class EntityPermissionsContextIdentifierType(Enum):
+    NIP = "Nip"
+    INTERNALID = "InternalId"
 
 class EntityPermissionsSubjectIdentifierType(Enum):
     NIP = "Nip"
@@ -734,6 +742,7 @@ class AttachmentPermissionRevokeRequest(OpenApiModel):
 @dataclass(frozen=True)
 class AuthenticationChallengeResponse(OpenApiModel):
     challenge: Challenge
+    clientIp: str
     timestamp: str
     timestampMs: int
 
@@ -996,11 +1005,29 @@ class EntityPermission(OpenApiModel):
     canDelegate: Optional[bool] = None
 
 @dataclass(frozen=True)
+class EntityPermissionItem(OpenApiModel):
+    canDelegate: bool
+    contextIdentifier: EntityPermissionsContextIdentifier
+    description: str
+    id: PermissionId
+    permissionScope: EntityPermissionItemScope
+    startDate: str
+
+@dataclass(frozen=True)
+class EntityPermissionsContextIdentifier(OpenApiModel):
+    type: EntityPermissionsContextIdentifierType
+    value: str
+
+@dataclass(frozen=True)
 class EntityPermissionsGrantRequest(OpenApiModel):
     description: str
     permissions: list[EntityPermission]
     subjectDetails: EntityDetails
     subjectIdentifier: EntityPermissionsSubjectIdentifier
+
+@dataclass(frozen=True)
+class EntityPermissionsQueryRequest(OpenApiModel):
+    contextIdentifier: Optional[EntityPermissionsContextIdentifier] = None
 
 @dataclass(frozen=True)
 class EntityPermissionsSubjectIdentifier(OpenApiModel):
@@ -1114,6 +1141,16 @@ class ExceptionResponse(OpenApiModel):
 @dataclass(frozen=True)
 class ExportInvoicesResponse(OpenApiModel):
     referenceNumber: ReferenceNumber
+
+@dataclass(frozen=True)
+class ForbiddenProblemDetails(OpenApiModel):
+    detail: str
+    reasonCode: str
+    status: int
+    title: str
+    instance: Optional[str] = None
+    security: Optional[dict[str, Optional[Any]]] = None
+    traceId: Optional[str] = None
 
 @dataclass(frozen=True)
 class FormCode(OpenApiModel):
@@ -1292,7 +1329,7 @@ class InvoiceStatusInfo(OpenApiModel):
     code: int
     description: str
     details: Optional[list[str]] = None
-    extensions: Optional[dict[str, Any]] = None
+    extensions: Optional[dict[str, Optional[str]]] = None
 
 @dataclass(frozen=True)
 class OnlineSessionContextLimitsOverride(OpenApiModel):
@@ -1330,7 +1367,7 @@ class OpenOnlineSessionResponse(OpenApiModel):
 
 @dataclass(frozen=True)
 class PartUploadRequest(OpenApiModel):
-    headers: dict[str, Any]
+    headers: dict[str, Optional[str]]
     method: str
     ordinalNumber: int
     url: str
@@ -1549,6 +1586,11 @@ class QueryCertificatesResponse(OpenApiModel):
 class QueryEntityAuthorizationPermissionsResponse(OpenApiModel):
     authorizationGrants: list[EntityAuthorizationGrant]
     hasMore: bool
+
+@dataclass(frozen=True)
+class QueryEntityPermissionsResponse(OpenApiModel):
+    hasMore: bool
+    permissions: list[EntityPermissionItem]
 
 @dataclass(frozen=True)
 class QueryEntityRolesResponse(OpenApiModel):
@@ -1854,6 +1896,14 @@ class TokenStatusResponse(OpenApiModel):
 @dataclass(frozen=True)
 class TooManyRequestsResponse(OpenApiModel):
     status: dict[str, Any]
+
+@dataclass(frozen=True)
+class UnauthorizedProblemDetails(OpenApiModel):
+    detail: str
+    status: int
+    title: str
+    instance: Optional[str] = None
+    traceId: Optional[str] = None
 
 @dataclass(frozen=True)
 class UnblockContextAuthenticationRequest(OpenApiModel):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -272,6 +272,9 @@ class ClientsTests(unittest.TestCase):
                 payload, page_offset=0, page_size=10, access_token="token"
             )
             client.query_entities_roles(page_offset=0, page_size=10, access_token="token")
+            client.query_entities_grants(
+                payload, page_offset=0, page_size=10, access_token="token"
+            )
             client.query_eu_entities_grants(
                 payload, page_offset=0, page_size=10, access_token="token"
             )
@@ -598,6 +601,12 @@ class AsyncClientsTests(unittest.IsolatedAsyncioTestCase):
                 access_token="token",
             )
             await permissions.query_entities_roles(
+                page_offset=0,
+                page_size=10,
+                access_token="token",
+            )
+            await permissions.query_entities_grants(
+                payload,
                 page_offset=0,
                 page_size=10,
                 access_token="token",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -10,12 +10,19 @@ from ksef_client.http import (
     BaseHttpClient,
     HttpResponse,
     _host_allowed,
+    _is_json_content_type,
     _merge_headers,
     _validate_presigned_url_security,
 )
 
 
 class HttpTests(unittest.TestCase):
+    def test_is_json_content_type(self):
+        self.assertTrue(_is_json_content_type("application/json"))
+        self.assertTrue(_is_json_content_type("application/problem+json"))
+        self.assertTrue(_is_json_content_type("application/vnd.api+json; charset=utf-8"))
+        self.assertFalse(_is_json_content_type("text/plain"))
+
     def test_merge_headers(self):
         base = {"a": "1"}
         merged = _merge_headers(base, {"b": "2"})
@@ -89,6 +96,24 @@ class HttpTests(unittest.TestCase):
         response = httpx.Response(400, json={"error": "bad"})
         with self.assertRaises(KsefApiError):
             client._raise_for_status(response)
+
+    def test_raise_for_status_problem_json_error(self):
+        options = KsefClientOptions(base_url="https://api-test.ksef.mf.gov.pl")
+        client = BaseHttpClient(options)
+        response = httpx.Response(
+            403,
+            headers={"Content-Type": "application/problem+json"},
+            json={
+                "title": "Forbidden",
+                "status": 403,
+                "detail": "Missing permissions",
+                "reasonCode": "missing-permissions",
+            },
+        )
+        with self.assertRaises(KsefApiError) as ctx:
+            client._raise_for_status(response)
+        assert isinstance(ctx.exception.response_body, dict)
+        self.assertEqual(ctx.exception.response_body["reasonCode"], "missing-permissions")
 
     def test_raise_for_status_http_error(self):
         options = KsefClientOptions(base_url="https://api-test.ksef.mf.gov.pl")
@@ -286,6 +311,18 @@ class AsyncHttpTests(unittest.IsolatedAsyncioTestCase):
         response_http = httpx.Response(500, content=b"boom", headers={"Content-Type": "text/plain"})
         with self.assertRaises(KsefHttpError):
             client._raise_for_status(response_http)
+
+        response_problem = httpx.Response(
+            401,
+            headers={"Content-Type": "application/problem+json"},
+            json={
+                "title": "Unauthorized",
+                "status": 401,
+                "detail": "Missing bearer token",
+            },
+        )
+        with self.assertRaises(KsefApiError):
+            client._raise_for_status(response_problem)
 
     async def test_async_skip_auth_presigned_validation_rejects_localhost(self):
         options = KsefClientOptions(base_url="https://api-test.ksef.mf.gov.pl")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,10 +11,16 @@ class ModelsTests(unittest.TestCase):
         self.assertEqual(token.valid_until, "2024-01-01")
 
     def test_auth_challenge_from_dict(self):
-        data = {"challenge": "c", "timestamp": "t", "timestampMs": 123}
+        data = {
+            "challenge": "c",
+            "timestamp": "t",
+            "timestampMs": 123,
+            "clientIp": "203.0.113.10",
+        }
         parsed = models.AuthenticationChallengeResponse.from_dict(data)
         self.assertEqual(parsed.challenge, "c")
         self.assertEqual(parsed.timestamp_ms, 123)
+        self.assertEqual(parsed.client_ip, "203.0.113.10")
 
     def test_auth_init_from_dict(self):
         data = {"referenceNumber": "ref", "authenticationToken": {"token": "tok"}}

--- a/tests/test_openapi_models.py
+++ b/tests/test_openapi_models.py
@@ -85,6 +85,45 @@ class OpenApiModelsTests(unittest.TestCase):
         values = {item.value for item in m.TokenPermissionType}
         self.assertIn("Introspection", values)
 
+    def test_authentication_challenge_response_contains_client_ip(self):
+        payload = {
+            "challenge": "challenge",
+            "timestamp": "2026-03-03T12:00:00+01:00",
+            "timestampMs": 1741009200000,
+            "clientIp": "203.0.113.10",
+        }
+        parsed = m.AuthenticationChallengeResponse.from_dict(payload)
+        self.assertEqual(parsed.clientIp, "203.0.113.10")
+        self.assertEqual(parsed.to_dict()["clientIp"], "203.0.113.10")
+
+    def test_problem_details_models_roundtrip(self):
+        forbidden_payload = {
+            "detail": "Missing permissions",
+            "reasonCode": "missing-permissions",
+            "status": 403,
+            "title": "Forbidden",
+            "security": {
+                "requiredAnyOfPermissions": ["InvoiceWrite"],
+                "presentPermissions": ["CredentialsRead"],
+            },
+            "traceId": "trace-1",
+        }
+        forbidden = m.ForbiddenProblemDetails.from_dict(forbidden_payload)
+        self.assertEqual(forbidden.reasonCode, "missing-permissions")
+        assert forbidden.security is not None
+        self.assertEqual(forbidden.security["presentPermissions"], ["CredentialsRead"])
+        self.assertEqual(forbidden.to_dict()["traceId"], "trace-1")
+
+        unauthorized_payload = {
+            "detail": "Missing bearer token",
+            "status": 401,
+            "title": "Unauthorized",
+            "instance": "/auth/challenge",
+        }
+        unauthorized = m.UnauthorizedProblemDetails.from_dict(unauthorized_payload)
+        self.assertEqual(unauthorized.status, 401)
+        self.assertEqual(unauthorized.to_dict()["instance"], "/auth/challenge")
+
     def test_token_permission_type_matches_openapi_when_available(self):
         repo_root = Path(__file__).resolve().parents[2]
         openapi_path = repo_root / "ksef-docs" / "open-api.json"


### PR DESCRIPTION
## Summary
- add support for `POST /permissions/query/entities/grants` (sync + async clients)
- regenerate OpenAPI models to include 2.2.0 schemas (`clientIp`, Problem Details, entity permissions query models)
- map `clientIp` in high-level auth challenge model
- handle `application/problem+json` (and other `+json`) in HTTP error parsing
- update docs compatibility reference to API 2.2.0

## Validation
- `.venv\\Scripts\\python.exe -m pip check`
- `.venv\\Scripts\\python.exe tools/lint.py`
- `.venv\\Scripts\\python.exe -m pytest --cov=ksef_client --cov-report=term-missing --cov-fail-under=100`
- `python tools/check_coverage.py --openapi ksef-docs/open-api.json --src src/ksef_client/clients --exclude-files lighthouse.py`
- `python tools/check_coverage.py --openapi ../temp/openapi-test-v2.json --src src/ksef_client/clients --exclude-files lighthouse.py`

Closes #24
