### PR TITLE
fix: default invoice list to all subject types

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -344,13 +344,17 @@ Usage: ksef invoice list [OPTIONS]
 Options:
   --from TEXT
   --to TEXT
-  --subject-type TEXT       [default: Subject1]
+  --subject-type TEXT
   --date-type TEXT          [default: Issue]
   --page-size INTEGER       [default: 10]
   --page-offset INTEGER     [default: 0]
   --sort-order [Asc|Desc]   [default: Desc]
   --base-url TEXT
 ```
+
+Uwagi:
+- bez `--subject-type` CLI agreguje wyniki dla wszystkich typów (`Subject1`, `Subject2`, `Subject3`, `SubjectAuthorized`),
+- podanie `--subject-type` zachowuje poprzednie, jawne filtrowanie do jednego kontekstu podmiotu.
 
 ## `ksef invoice download`
 

--- a/src/ksef_client/cli/commands/invoice_cmd.py
+++ b/src/ksef_client/cli/commands/invoice_cmd.py
@@ -72,8 +72,10 @@ def invoice_list(
     ctx: typer.Context,
     date_from: str | None = typer.Option(None, "--from", help="Start date (YYYY-MM-DD)."),
     date_to: str | None = typer.Option(None, "--to", help="End date (YYYY-MM-DD)."),
-    subject_type: str = typer.Option(
-        "Subject1", "--subject-type", help="KSeF subject type filter."
+    subject_type: str | None = typer.Option(
+        None,
+        "--subject-type",
+        help="KSeF subject type filter. Omit to query all subject types.",
     ),
     date_type: str = typer.Option(
         "Issue", "--date-type", help="Date field used in filter, e.g. Issue."

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -25,6 +25,22 @@ from .factory import create_client
 
 _TRANSIENT_UPO_CODES = {404, 409, 425}
 _PENDING_STATUS_CODES = {100, 150}
+_DEFAULT_INVOICE_QUERY_SUBJECT_TYPES = (
+    m.InvoiceQuerySubjectType.SUBJECT1,
+    m.InvoiceQuerySubjectType.SUBJECT2,
+    m.InvoiceQuerySubjectType.SUBJECT3,
+    m.InvoiceQuerySubjectType.SUBJECTAUTHORIZED,
+)
+_INVOICE_SORT_DATE_FIELDS = {
+    m.InvoiceQueryDateType.ISSUE.value: (("issue_date", "issueDate"),),
+    m.InvoiceQueryDateType.INVOICING.value: (
+        ("invoicing_date", "invoicingDate"),
+        ("acquisition_date", "acquisitionDate"),
+    ),
+    m.InvoiceQueryDateType.PERMANENTSTORAGE.value: (
+        ("permanent_storage_date", "permanentStorageDate"),
+    ),
+}
 
 
 def _is_transient_polling_http(status_code: int) -> bool:
@@ -257,6 +273,159 @@ def _require_encryption_info(encryption: EncryptionData) -> m.EncryptionInfo:
             "Regenerate encryption data before opening a session or export.",
         )
     return encryption_info
+
+
+def _build_invoice_query_filters(
+    *,
+    subject_type: m.InvoiceQuerySubjectType,
+    date_type: m.InvoiceQueryDateType,
+    from_iso: str,
+    to_iso: str,
+) -> m.InvoiceQueryFilters:
+    return m.InvoiceQueryFilters(
+        subject_type=subject_type,
+        date_range=m.InvoiceQueryDateRange(
+            date_type=date_type,
+            from_=from_iso,
+            to=to_iso,
+        ),
+    )
+
+
+def _extract_invoice_items(response: Any) -> list[Any]:
+    invoices = _get_value(response, "invoices", default=[]) or []
+    if isinstance(response, dict) and not invoices:
+        invoices = response.get("invoiceList") or []
+    return invoices if isinstance(invoices, list) else []
+
+
+def _normalize_invoice_sort_value(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.isoformat()
+
+
+def _invoice_identity_key(invoice: Any) -> str:
+    for attr_name, json_name in (
+        ("ksef_number", "ksefNumber"),
+        ("invoice_hash", "invoiceHash"),
+    ):
+        value = _get_value(invoice, attr_name, json_name)
+        if value:
+            return f"{json_name}:{value}"
+    payload = _to_output_payload(invoice)
+    if isinstance(payload, dict):
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    return repr(payload)
+
+
+def _invoice_sort_key(invoice: Any, *, date_type: m.InvoiceQueryDateType) -> tuple[str, str, str]:
+    date_value = ""
+    for attr_name, json_name in _INVOICE_SORT_DATE_FIELDS.get(date_type.value, ()):
+        candidate = _get_value(invoice, attr_name, json_name)
+        if candidate:
+            date_value = _normalize_invoice_sort_value(candidate)
+            break
+    reference = str(
+        _get_value(invoice, "ksef_number", "ksefNumber")
+        or _get_value(invoice, "invoice_number", "invoiceNumber")
+        or _get_value(invoice, "invoice_hash", "invoiceHash")
+        or ""
+    )
+    return (
+        date_value,
+        reference,
+        _invoice_identity_key(invoice),
+    )
+
+
+def _query_invoice_metadata_page(
+    *,
+    client: Any,
+    access_token: str,
+    subject_type: m.InvoiceQuerySubjectType,
+    date_type: m.InvoiceQueryDateType,
+    from_iso: str,
+    to_iso: str,
+    page_size: int,
+    page_offset: int,
+    sort_order: str,
+) -> Any:
+    return client.invoices.query_invoice_metadata(
+        _build_invoice_query_filters(
+            subject_type=subject_type,
+            date_type=date_type,
+            from_iso=from_iso,
+            to_iso=to_iso,
+        ),
+        access_token=access_token,
+        page_offset=page_offset,
+        page_size=page_size,
+        sort_order=sort_order,
+    )
+
+
+def _query_all_invoice_subject_types(
+    *,
+    client: Any,
+    access_token: str,
+    date_type: m.InvoiceQueryDateType,
+    from_iso: str,
+    to_iso: str,
+    page_size: int,
+    page_offset: int,
+    sort_order: str,
+) -> list[Any]:
+    batch_size = page_size if page_size > 0 else 0
+    aggregated: list[Any] = []
+
+    for subject_type in _DEFAULT_INVOICE_QUERY_SUBJECT_TYPES:
+        request_offset = 0
+        while True:
+            response = _query_invoice_metadata_page(
+                client=client,
+                access_token=access_token,
+                subject_type=subject_type,
+                date_type=date_type,
+                from_iso=from_iso,
+                to_iso=to_iso,
+                page_size=page_size,
+                page_offset=request_offset,
+                sort_order=sort_order,
+            )
+            invoices = _extract_invoice_items(response)
+            if not invoices:
+                break
+            aggregated.extend(invoices)
+            if batch_size <= 0 or len(invoices) < batch_size:
+                break
+            request_offset += batch_size
+
+    unique_invoices: dict[str, Any] = {}
+    for invoice in aggregated:
+        unique_invoices.setdefault(_invoice_identity_key(invoice), invoice)
+
+    sorted_invoices = sorted(
+        unique_invoices.values(),
+        key=lambda invoice: _invoice_sort_key(invoice, date_type=date_type),
+        reverse=sort_order.casefold() == "desc",
+    )
+    if page_offset < 0:
+        page_offset = 0
+    if page_size <= 0:
+        return sorted_invoices[page_offset:]
+    return sorted_invoices[page_offset : page_offset + page_size]
 
 
 def _load_invoice_xml(path: str) -> bytes:
@@ -569,7 +738,7 @@ def list_invoices(
     base_url: str,
     date_from: str | None,
     date_to: str | None,
-    subject_type: str,
+    subject_type: str | None,
     date_type: str,
     page_size: int,
     page_offset: int,
@@ -577,28 +746,35 @@ def list_invoices(
 ) -> dict[str, Any]:
     access_token = _require_access_token(profile)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
-    payload = m.InvoiceQueryFilters(
-        subject_type=_require_invoice_query_subject_type(subject_type),
-        date_range=m.InvoiceQueryDateRange(
-            date_type=_require_invoice_query_date_type(date_type),
-            from_=from_iso,
-            to=to_iso,
-        ),
-    )
+    resolved_date_type = _require_invoice_query_date_type(date_type)
 
     with create_client(base_url, access_token=access_token) as client:
-        response = client.invoices.query_invoice_metadata(
-            payload,
-            access_token=access_token,
-            page_offset=page_offset,
-            page_size=page_size,
-            sort_order=sort_order,
-        )
-
-    invoices = _get_value(response, "invoices", default=[]) or []
-    if isinstance(response, dict) and not invoices:
-        invoices = response.get("invoiceList") or []
-    continuation_token = _get_value(response, "continuation_token", "continuationToken", "")
+        continuation_token = ""
+        if subject_type is None:
+            invoices = _query_all_invoice_subject_types(
+                client=client,
+                access_token=access_token,
+                date_type=resolved_date_type,
+                from_iso=from_iso,
+                to_iso=to_iso,
+                page_size=page_size,
+                page_offset=page_offset,
+                sort_order=sort_order,
+            )
+        else:
+            response = _query_invoice_metadata_page(
+                client=client,
+                access_token=access_token,
+                subject_type=_require_invoice_query_subject_type(subject_type),
+                date_type=resolved_date_type,
+                from_iso=from_iso,
+                to_iso=to_iso,
+                page_size=page_size,
+                page_offset=page_offset,
+                sort_order=sort_order,
+            )
+            invoices = _extract_invoice_items(response)
+            continuation_token = _get_value(response, "continuation_token", "continuationToken", "")
     return {
         "count": len(invoices),
         "from": from_iso,

--- a/tests/cli/integration/test_invoice_list.py
+++ b/tests/cli/integration/test_invoice_list.py
@@ -63,6 +63,21 @@ def test_invoice_list_success(runner, monkeypatch) -> None:
     assert "invoice.list" in result.stdout
 
 
+def test_invoice_list_defaults_to_all_subject_types(runner, monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_list(**kwargs):
+        seen.update(kwargs)
+        return {"count": 0, "items": [], "continuation_token": "", "from": "", "to": ""}
+
+    monkeypatch.setattr(invoice_cmd, "list_invoices", _fake_list)
+
+    result = runner.invoke(app, ["invoice", "list"])
+
+    assert result.exit_code == 0
+    assert seen["subject_type"] is None
+
+
 def test_invoice_list_json_success(runner, monkeypatch) -> None:
     monkeypatch.setattr(
         invoice_cmd,

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1214,6 +1214,67 @@ def test_list_invoices_uses_default_from_and_invoice_list_key(monkeypatch) -> No
     assert result["items"][0]["ksefReferenceNumber"] == "KSEF-X"
 
 
+def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatch) -> None:
+    seen_calls: list[tuple[str, int, int]] = []
+
+    responses = {
+        ("Subject1", 0): {
+            "invoices": [
+                {"ksefNumber": "KSEF-2", "issueDate": "2026-01-03T00:00:00Z"},
+                {"ksefNumber": "KSEF-DUP", "issueDate": "2026-01-02T00:00:00Z"},
+            ]
+        },
+        ("Subject1", 2): {"invoices": []},
+        ("Subject2", 0): {
+            "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-04T00:00:00Z"}]
+        },
+        ("Subject3", 0): {
+            "invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]
+        },
+        ("SubjectAuthorized", 0): {
+            "invoices": [{"ksefNumber": "KSEF-DUP", "issueDate": "2026-01-02T00:00:00Z"}]
+        },
+    }
+
+    class _Invoices:
+        def query_invoice_metadata(self, payload, **kwargs):
+            subject_type = payload.subject_type.value
+            page_offset = int(kwargs.get("page_offset", 0) or 0)
+            page_size = int(kwargs.get("page_size", 0) or 0)
+            seen_calls.append((subject_type, page_offset, page_size))
+            return responses[(subject_type, page_offset)]
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(invoices=_Invoices()),
+    )
+
+    result = adapters.list_invoices(
+        profile="demo",
+        base_url="https://example.invalid",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        subject_type=None,
+        date_type="Issue",
+        page_size=2,
+        page_offset=1,
+        sort_order="Desc",
+    )
+
+    assert seen_calls == [
+        ("Subject1", 0, 2),
+        ("Subject1", 2, 2),
+        ("Subject2", 0, 2),
+        ("Subject3", 0, 2),
+        ("SubjectAuthorized", 0, 2),
+    ]
+    assert result["count"] == 2
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-2", "KSEF-DUP"]
+    assert result["continuation_token"] == ""
+
+
 def test_resolve_output_path_for_plain_path_segment() -> None:
     path = adapters._resolve_output_path("artifacts", default_filename="out.xml")
     assert path.as_posix().endswith("artifacts")

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1275,6 +1275,57 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
     assert result["continuation_token"] == ""
 
 
+def test_invoice_sort_value_handles_empty_invalid_and_naive_datetime() -> None:
+    assert adapters._normalize_invoice_sort_value(None) == ""
+    assert adapters._normalize_invoice_sort_value("   ") == ""
+    assert adapters._normalize_invoice_sort_value("not-a-date") == "not-a-date"
+    assert adapters._normalize_invoice_sort_value("2026-01-05T12:30:00") == (
+        "2026-01-05T12:30:00+00:00"
+    )
+
+
+def test_invoice_identity_key_falls_back_to_serialized_payload_and_repr() -> None:
+    class _PlainObject:
+        pass
+
+    payload_key = adapters._invoice_identity_key(_ToDictPayload())
+    repr_key = adapters._invoice_identity_key(_PlainObject())
+
+    assert payload_key == '{"value": "ok"}'
+    assert "_PlainObject object" in repr_key
+
+
+def test_query_all_invoice_subject_types_handles_negative_offset_and_unbounded_page_size(
+    monkeypatch,
+) -> None:
+    responses = {
+        ("Subject1", 0): [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}],
+        ("Subject2", 0): [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}],
+        ("Subject3", 0): [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}],
+        ("SubjectAuthorized", 0): [],
+    }
+
+    def _fake_query_page(**kwargs):
+        subject_type = kwargs["subject_type"].value
+        page_offset = kwargs["page_offset"]
+        return {"invoices": responses[(subject_type, page_offset)]}
+
+    monkeypatch.setattr(adapters, "_query_invoice_metadata_page", _fake_query_page)
+
+    result = adapters._query_all_invoice_subject_types(
+        client=object(),
+        access_token="token",
+        date_type=m.InvoiceQueryDateType.ISSUE,
+        from_iso="2026-01-01T00:00:00Z",
+        to_iso="2026-01-31T23:59:59Z",
+        page_size=0,
+        page_offset=-5,
+        sort_order="Asc",
+    )
+
+    assert [item["ksefNumber"] for item in result] == ["KSEF-1", "KSEF-2", "KSEF-3"]
+
+
 def test_resolve_output_path_for_plain_path_segment() -> None:
     path = adapters._resolve_output_path("artifacts", default_filename="out.xml")
     assert path.as_posix().endswith("artifacts")


### PR DESCRIPTION
## Summary
- make \\ksef invoice list\\ aggregate results from all invoice subject types when \\--subject-type\\ is omitted
- keep explicit \\--subject-type\\ behavior unchanged
- add CLI docs and coverage for aggregation, deduplication, sorting, and paging

## Testing
- python -m ruff check src/ksef_client/cli/commands/invoice_cmd.py src/ksef_client/cli/sdk/adapters.py tests/cli/integration/test_invoice_list.py tests/cli/unit/test_sdk_adapters.py
- pytest tests/cli/integration/test_invoice_list.py tests/cli/unit/test_sdk_adapters.py -q
- pytest tests/cli -q

Fixes #35