### PR TITLE
fix(cli): remove export sort-order no-op and harden invoice list aggregation

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -364,7 +364,7 @@ Options:
   --to TEXT
   --subject-type TEXT
   --date-type TEXT          [default: Issue]
-  --page-size INTEGER       [default: 10]
+  --page-size INTEGER       [default: 10, min: 10, max: 250]
   --page-offset INTEGER     [default: 0]
   --sort-order [Asc|Desc]   [default: Desc]
   --base-url TEXT
@@ -373,6 +373,16 @@ Options:
 Uwagi:
 - bez `--subject-type` CLI agreguje wyniki dla wszystkich typów (`Subject1`, `Subject2`, `Subject3`, `SubjectAuthorized`),
 - podanie `--subject-type` zachowuje poprzednie, jawne filtrowanie do jednego kontekstu podmiotu.
+- zakres `--from/--to` nie moze przekraczac 3 miesiecy.
+
+Kontrakt `data` dla `ksef invoice list --json`:
+- `count`: liczba rekordow w biezacej stronie po filtracji,
+- `from`, `to`: efektywny zakres dat wykorzystany w zapytaniu,
+- `items`: lista rekordow faktur,
+- `has_more`: czy API sygnalizuje kolejne dane do pobrania,
+- `is_truncated`: czy API zwrocilo odpowiedz obcieta po stronie serwera,
+- `permanent_storage_hwm_date`: znacznik HWM z API (dla synchronizacji przyrostowej),
+- `continuation_token`: pole kompatybilnosciowe; CLI nie generuje sztucznej wartosci i moze byc `null`.
 
 ## `ksef invoice download`
 
@@ -490,7 +500,10 @@ Usage: ksef export run [OPTIONS]
 Options:
   --from TEXT
   --to TEXT
+  --date-type TEXT          [default: Issue]
+  --sort-order TEXT         [default: Asc]
   --subject-type TEXT        [default: Subject1]
+  --restrict-to-permanent-storage-hwm-date / --no-restrict-to-permanent-storage-hwm-date
   --only-metadata
   --poll-interval FLOAT      [default: 2.0]
   --max-attempts INTEGER     [default: 120]
@@ -500,6 +513,8 @@ Options:
 
 Uwagi:
 - `--only-metadata` pobiera tylko `_metadata.json` bez XML faktur.
+- `--sort-order` jest wspierane tylko jako `Asc`; inne wartosci sa odrzucane walidacja CLI.
+- dla eksportu przyrostowego uzyj `--date-type PermanentStorage` razem z `--restrict-to-permanent-storage-hwm-date`.
 
 ## Exit codes
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -501,7 +501,6 @@ Options:
   --from TEXT
   --to TEXT
   --date-type TEXT          [default: Issue]
-  --sort-order TEXT         [default: Asc]
   --subject-type TEXT        [default: Subject1]
   --restrict-to-permanent-storage-hwm-date / --no-restrict-to-permanent-storage-hwm-date
   --only-metadata
@@ -513,7 +512,6 @@ Options:
 
 Uwagi:
 - `--only-metadata` pobiera tylko `_metadata.json` bez XML faktur.
-- `--sort-order` jest wspierane tylko jako `Asc`; inne wartosci sa odrzucane walidacja CLI.
 - dla eksportu przyrostowego uzyj `--date-type PermanentStorage` razem z `--restrict-to-permanent-storage-hwm-date`.
 
 ## Exit codes

--- a/docs/workflows/export.md
+++ b/docs/workflows/export.md
@@ -92,7 +92,6 @@ ksef export run \
   --from 2025-08-28 \
   --to 2025-09-28 \
   --date-type PermanentStorage \
-  --sort-order Asc \
   --restrict-to-permanent-storage-hwm-date \
   --subject-type Subject1 \
   --out ./out/export
@@ -100,11 +99,9 @@ ksef export run \
 
 Mapowanie opcji CLI na payload eksportu:
 - `--date-type` -> `filters.dateRange.dateType`
-- `--sort-order` -> `filters.sortOrder`
 - `--restrict-to-permanent-storage-hwm-date` -> `filters.dateRange.restrictToPermanentStorageHwmDate`
 - `--subject-type` -> `filters.subjectType`
 - `--only-metadata` -> `onlyMetadata`
 
 Uwagi:
-- CLI wspiera `--sort-order` tylko jako `Asc` (inne wartosci sa odrzucane).
 - Dla synchronizacji przyrostowej/HWM uzyj `--date-type PermanentStorage` razem z `--restrict-to-permanent-storage-hwm-date`.

--- a/docs/workflows/export.md
+++ b/docs/workflows/export.md
@@ -82,3 +82,29 @@ print(len(result.metadata_summaries), len(result.invoice_xml_files))
 - Paczka eksportu zawiera `_metadata.json` (dla deduplikacji i synchronizacji przyrostowej).
 
 Do HWM i deduplikacji: [HWM](../services/hwm.md).
+
+## CLI: odpowiednik workflow
+
+To samo mozna wykonac komenda:
+
+```bash
+ksef export run \
+  --from 2025-08-28 \
+  --to 2025-09-28 \
+  --date-type PermanentStorage \
+  --sort-order Asc \
+  --restrict-to-permanent-storage-hwm-date \
+  --subject-type Subject1 \
+  --out ./out/export
+```
+
+Mapowanie opcji CLI na payload eksportu:
+- `--date-type` -> `filters.dateRange.dateType`
+- `--sort-order` -> `filters.sortOrder`
+- `--restrict-to-permanent-storage-hwm-date` -> `filters.dateRange.restrictToPermanentStorageHwmDate`
+- `--subject-type` -> `filters.subjectType`
+- `--only-metadata` -> `onlyMetadata`
+
+Uwagi:
+- CLI wspiera `--sort-order` tylko jako `Asc` (inne wartosci sa odrzucane).
+- Dla synchronizacji przyrostowej/HWM uzyj `--date-type PermanentStorage` razem z `--restrict-to-permanent-storage-hwm-date`.

--- a/src/ksef_client/cli/auth/manager.py
+++ b/src/ksef_client/cli/auth/manager.py
@@ -29,6 +29,22 @@ def _discover_current_token_reference_number(
     access_token: str,
     profile: str,
 ) -> str | None:
+    matched_references = _collect_active_token_reference_numbers(
+        client=client,
+        access_token=access_token,
+        profile=profile,
+    )
+    if len(matched_references) == 1:
+        return next(iter(matched_references))
+    return None
+
+
+def _collect_active_token_reference_numbers(
+    *,
+    client: Any,
+    access_token: str,
+    profile: str,
+) -> set[str]:
     continuation_token: str | None = None
     seen_continuation_tokens: set[str] = set()
     matched_references: set[str] = set()
@@ -60,8 +76,6 @@ def _discover_current_token_reference_number(
             ):
                 continue
             matched_references.add(str(item.reference_number))
-            if len(matched_references) > 1:
-                return None
 
         continuation_token = listed.continuation_token
         if not continuation_token:
@@ -70,9 +84,7 @@ def _discover_current_token_reference_number(
             break
         seen_continuation_tokens.add(continuation_token)
 
-    if len(matched_references) == 1:
-        return next(iter(matched_references))
-    return None
+    return matched_references
 
 
 def _select_certificate(certs: list[Any], usage_name: str) -> str:
@@ -422,11 +434,21 @@ def revoke_self_token(*, profile: str, base_url: str) -> dict[str, Any]:
     with create_client(base_url) as client:
         reference_number = metadata.get("ksef_token_reference_number", "").strip()
         if not reference_number:
-            reference_number = _discover_current_token_reference_number(
+            matched_references = _collect_active_token_reference_numbers(
                 client=client,
                 access_token=access_token,
                 profile=profile,
-            ) or ""
+            )
+            if len(matched_references) > 1:
+                formatted_references = ", ".join(sorted(matched_references))
+                raise CliError(
+                    "Cannot safely identify current KSeF token reference number: "
+                    f"multiple active tokens match the profile context ({formatted_references}).",
+                    ExitCode.AUTH_ERROR,
+                    "Set `ksef_token_reference_number` in profile metadata or login again "
+                    "with the exact token intended for self-revoke.",
+                )
+            reference_number = next(iter(matched_references), "")
         if not reference_number:
             raise CliError(
                 "Missing KSeF token reference number for the current profile.",

--- a/src/ksef_client/cli/commands/export_cmd.py
+++ b/src/ksef_client/cli/commands/export_cmd.py
@@ -77,11 +77,6 @@ def export_run(
         "--date-type",
         help="Date field for filtering (Issue, Invoicing, PermanentStorage).",
     ),
-    sort_order: str = typer.Option(
-        "Asc",
-        "--sort-order",
-        help="Sort order for export workflow (OpenAPI allows only Asc).",
-    ),
     subject_type: str = typer.Option(
         "Subject1", "--subject-type", help="KSeF subject type filter."
     ),
@@ -115,7 +110,6 @@ def export_run(
             date_from=date_from,
             date_to=date_to,
             date_type=date_type,
-            sort_order=sort_order,
             subject_type=subject_type,
             restrict_to_permanent_storage_hwm_date=restrict_to_permanent_storage_hwm_date,
             only_metadata=only_metadata,

--- a/src/ksef_client/cli/commands/export_cmd.py
+++ b/src/ksef_client/cli/commands/export_cmd.py
@@ -72,8 +72,23 @@ def export_run(
     ctx: typer.Context,
     date_from: str | None = typer.Option(None, "--from", help="Start date (YYYY-MM-DD)."),
     date_to: str | None = typer.Option(None, "--to", help="End date (YYYY-MM-DD)."),
+    date_type: str = typer.Option(
+        "Issue",
+        "--date-type",
+        help="Date field for filtering (Issue, Invoicing, PermanentStorage).",
+    ),
+    sort_order: str = typer.Option(
+        "Asc",
+        "--sort-order",
+        help="Sort order for export workflow (OpenAPI allows only Asc).",
+    ),
     subject_type: str = typer.Option(
         "Subject1", "--subject-type", help="KSeF subject type filter."
+    ),
+    restrict_to_permanent_storage_hwm_date: bool = typer.Option(
+        False,
+        "--restrict-to-permanent-storage-hwm-date/--no-restrict-to-permanent-storage-hwm-date",
+        help="Use PermanentStorageHwmDate guard from API for incremental export.",
     ),
     only_metadata: bool = typer.Option(
         False,
@@ -99,7 +114,10 @@ def export_run(
             base_url=resolve_base_url(base_url or os.getenv("KSEF_BASE_URL"), profile=profile),
             date_from=date_from,
             date_to=date_to,
+            date_type=date_type,
+            sort_order=sort_order,
             subject_type=subject_type,
+            restrict_to_permanent_storage_hwm_date=restrict_to_permanent_storage_hwm_date,
             only_metadata=only_metadata,
             poll_interval=poll_interval,
             max_attempts=max_attempts,

--- a/src/ksef_client/cli/commands/invoice_cmd.py
+++ b/src/ksef_client/cli/commands/invoice_cmd.py
@@ -93,7 +93,12 @@ def invoice_list(
         max=250,
         help="Number of items per page (10-250).",
     ),
-    page_offset: int = typer.Option(0, "--page-offset", help="Pagination offset."),
+    page_offset: int = typer.Option(
+        0,
+        "--page-offset",
+        min=0,
+        help="Pagination offset (0 or greater).",
+    ),
     sort_order: SortOrder = typer.Option(  # noqa: B008
         SortOrder.DESC,
         "--sort-order",

--- a/src/ksef_client/cli/commands/invoice_cmd.py
+++ b/src/ksef_client/cli/commands/invoice_cmd.py
@@ -86,7 +86,13 @@ def invoice_list(
     date_type: str = typer.Option(
         "Issue", "--date-type", help="Date field used in filter, e.g. Issue."
     ),
-    page_size: int = typer.Option(10, "--page-size", help="Number of items per page."),
+    page_size: int = typer.Option(
+        10,
+        "--page-size",
+        min=10,
+        max=250,
+        help="Number of items per page (10-250).",
+    ),
     page_offset: int = typer.Option(0, "--page-offset", help="Pagination offset."),
     sort_order: SortOrder = typer.Option(  # noqa: B008
         SortOrder.DESC,

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -142,6 +142,16 @@ def _require_invoice_query_page_size(value: int) -> int:
     )
 
 
+def _require_non_negative_page_offset(value: int) -> int:
+    if value >= 0:
+        return value
+    raise CliError(
+        "Invalid page offset.",
+        ExitCode.VALIDATION_ERROR,
+        "--page-offset must be 0 or greater.",
+    )
+
+
 def _resolve_output_path(
     out: str,
     *,
@@ -355,6 +365,16 @@ def _merge_permanent_storage_hwm_date(current: str, candidate: str) -> str:
     current_normalized = _normalize_invoice_sort_value(current_value)
     candidate_normalized = _normalize_invoice_sort_value(candidate_value)
 
+    current_valid = _is_iso_datetime(current_value)
+    candidate_valid = _is_iso_datetime(candidate_value)
+
+    if current_valid and not candidate_valid:
+        return current_value
+    if candidate_valid and not current_valid:
+        return candidate_value
+    if not current_valid and not candidate_valid:
+        return current_value
+
     if candidate_normalized < current_normalized:
         return candidate_value
     return current_value
@@ -375,6 +395,14 @@ def _normalize_invoice_sort_value(value: Any) -> str:
     else:
         parsed = parsed.astimezone(timezone.utc)
     return parsed.isoformat()
+
+
+def _is_iso_datetime(value: str) -> bool:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 def _invoice_identity_key(invoice: Any) -> str:
@@ -883,6 +911,7 @@ def list_invoices(
 ) -> dict[str, Any]:
     access_token = _require_access_token(profile)
     normalized_page_size = _require_invoice_query_page_size(page_size)
+    normalized_page_offset = _require_non_negative_page_offset(page_offset)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
     resolved_date_type = _require_invoice_query_date_type(date_type)
 
@@ -899,7 +928,7 @@ def list_invoices(
                 from_iso=from_iso,
                 to_iso=to_iso,
                 page_size=normalized_page_size,
-                page_offset=page_offset,
+                page_offset=normalized_page_offset,
                 sort_order=sort_order,
             )
             invoices = aggregated["items"]
@@ -915,7 +944,7 @@ def list_invoices(
                 from_iso=from_iso,
                 to_iso=to_iso,
                 page_size=normalized_page_size,
-                page_offset=page_offset,
+                page_offset=normalized_page_offset,
                 sort_order=sort_order,
             )
             invoices = _extract_invoice_items(response)

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -309,6 +309,25 @@ def _extract_invoice_items(response: Any) -> list[Any]:
     return invoices if isinstance(invoices, list) else []
 
 
+def _extract_invoice_query_metadata(response: Any) -> tuple[bool, bool, str, str]:
+    has_more_raw = _get_value(response, "has_more", "hasMore", None)
+    continuation_token = str(
+        _get_value(response, "continuation_token", "continuationToken", "") or ""
+    )
+    has_more = bool(has_more_raw) if has_more_raw is not None else bool(continuation_token)
+    is_truncated = bool(_get_value(response, "is_truncated", "isTruncated", False))
+    permanent_storage_hwm_date = str(
+        _get_value(
+            response,
+            "permanent_storage_hwm_date",
+            "permanentStorageHwmDate",
+            "",
+        )
+        or ""
+    )
+    return has_more, is_truncated, permanent_storage_hwm_date, continuation_token
+
+
 def _normalize_invoice_sort_value(value: Any) -> str:
     if value is None:
         return ""
@@ -396,46 +415,116 @@ def _query_all_invoice_subject_types(
     page_size: int,
     page_offset: int,
     sort_order: str,
-) -> list[Any]:
-    batch_size = page_size if page_size > 0 else 0
-    aggregated: list[Any] = []
-
-    for subject_type in _DEFAULT_INVOICE_QUERY_SUBJECT_TYPES:
-        request_offset = 0
-        while True:
-            response = _query_invoice_metadata_page(
-                client=client,
-                access_token=access_token,
-                subject_type=subject_type,
-                date_type=date_type,
-                from_iso=from_iso,
-                to_iso=to_iso,
-                page_size=page_size,
-                page_offset=request_offset,
-                sort_order=sort_order,
-            )
-            invoices = _extract_invoice_items(response)
-            if not invoices:
-                break
-            aggregated.extend(invoices)
-            if batch_size <= 0 or len(invoices) < batch_size:
-                break
-            request_offset += batch_size
-
-    unique_invoices: dict[str, Any] = {}
-    for invoice in aggregated:
-        unique_invoices.setdefault(_invoice_identity_key(invoice), invoice)
-
-    sorted_invoices = sorted(
-        unique_invoices.values(),
-        key=lambda invoice: _invoice_sort_key(invoice, date_type=date_type),
-        reverse=sort_order.casefold() == "desc",
-    )
-    if page_offset < 0:
-        page_offset = 0
+) -> dict[str, Any]:
+    normalized_offset = max(page_offset, 0)
     if page_size <= 0:
-        return sorted_invoices[page_offset:]
-    return sorted_invoices[page_offset : page_offset + page_size]
+        limit = None
+    else:
+        limit = normalized_offset + page_size + 1
+    reverse_order = sort_order.casefold() == "desc"
+
+    stream_states: list[dict[str, Any]] = [
+        {
+            "subject_type": subject_type,
+            "next_offset": 0,
+            "invoices": [],
+            "index": 0,
+            "exhausted": False,
+        }
+        for subject_type in _DEFAULT_INVOICE_QUERY_SUBJECT_TYPES
+    ]
+    aggregated: list[Any] = []
+    dedupe_keys: set[str] = set()
+    aggregated_has_more = False
+    aggregated_is_truncated = False
+    permanent_storage_hwm_date = ""
+
+    def _load_next_page(state: dict[str, Any]) -> None:
+        nonlocal aggregated_has_more
+        nonlocal aggregated_is_truncated
+        nonlocal permanent_storage_hwm_date
+
+        if state["exhausted"]:
+            return
+
+        response = _query_invoice_metadata_page(
+            client=client,
+            access_token=access_token,
+            subject_type=state["subject_type"],
+            date_type=date_type,
+            from_iso=from_iso,
+            to_iso=to_iso,
+            page_size=page_size,
+            page_offset=state["next_offset"],
+            sort_order=sort_order,
+        )
+        invoices = _extract_invoice_items(response)
+        has_more_raw = _get_value(response, "has_more", "hasMore", None)
+        has_more, is_truncated, hwm_date, _ = _extract_invoice_query_metadata(response)
+        state["invoices"] = invoices
+        state["index"] = 0
+        state["next_offset"] += max(page_size, 0)
+
+        aggregated_has_more = aggregated_has_more or has_more
+        aggregated_is_truncated = aggregated_is_truncated or is_truncated
+        if hwm_date and not permanent_storage_hwm_date:
+            permanent_storage_hwm_date = hwm_date
+
+        if not invoices:
+            state["exhausted"] = True
+            return
+        if page_size <= 0:
+            state["exhausted"] = True
+            return
+        if has_more_raw is not None:
+            state["exhausted"] = not bool(has_more_raw)
+            return
+        if len(invoices) < page_size:
+            state["exhausted"] = True
+
+    def _ensure_stream_head(state: dict[str, Any]) -> bool:
+        while True:
+            if state["index"] < len(state["invoices"]):
+                return True
+            if state["exhausted"]:
+                return False
+            _load_next_page(state)
+
+    while True:
+        if limit is not None and len(aggregated) >= limit:
+            break
+        available_states = [state for state in stream_states if _ensure_stream_head(state)]
+        if not available_states:
+            break
+        selected_state = (
+            max(available_states, key=lambda state: _invoice_sort_key(state["invoices"][state["index"]], date_type=date_type))
+            if reverse_order
+            else min(available_states, key=lambda state: _invoice_sort_key(state["invoices"][state["index"]], date_type=date_type))
+        )
+        invoice = selected_state["invoices"][selected_state["index"]]
+        selected_state["index"] += 1
+        invoice_key = _invoice_identity_key(invoice)
+        if invoice_key in dedupe_keys:
+            continue
+        dedupe_keys.add(invoice_key)
+        aggregated.append(invoice)
+
+    if page_size <= 0:
+        items = aggregated[normalized_offset:]
+        has_more = False
+    else:
+        page_end = normalized_offset + page_size
+        items = aggregated[normalized_offset:page_end]
+        has_more = len(aggregated) > page_end
+        if not has_more and aggregated_has_more and len(aggregated) >= page_end:
+            has_more = True
+
+    return {
+        "items": items,
+        "has_more": has_more,
+        "is_truncated": aggregated_is_truncated,
+        "permanent_storage_hwm_date": permanent_storage_hwm_date,
+    }
 
 
 def _load_invoice_xml(path: str) -> bytes:
@@ -760,8 +849,11 @@ def list_invoices(
 
     with create_client(base_url, access_token=access_token) as client:
         continuation_token = ""
+        has_more = False
+        is_truncated = False
+        permanent_storage_hwm_date = ""
         if subject_type is None:
-            invoices = _query_all_invoice_subject_types(
+            aggregated = _query_all_invoice_subject_types(
                 client=client,
                 access_token=access_token,
                 date_type=resolved_date_type,
@@ -771,6 +863,10 @@ def list_invoices(
                 page_offset=page_offset,
                 sort_order=sort_order,
             )
+            invoices = aggregated["items"]
+            has_more = bool(aggregated["has_more"])
+            is_truncated = bool(aggregated["is_truncated"])
+            permanent_storage_hwm_date = str(aggregated["permanent_storage_hwm_date"] or "")
         else:
             response = _query_invoice_metadata_page(
                 client=client,
@@ -784,13 +880,18 @@ def list_invoices(
                 sort_order=sort_order,
             )
             invoices = _extract_invoice_items(response)
-            continuation_token = _get_value(response, "continuation_token", "continuationToken", "")
+            has_more, is_truncated, permanent_storage_hwm_date, continuation_token = (
+                _extract_invoice_query_metadata(response)
+            )
     return {
         "count": len(invoices),
         "from": from_iso,
         "to": to_iso,
         "items": [_to_output_payload(item) for item in invoices],
         "continuation_token": continuation_token or "",
+        "has_more": bool(has_more),
+        "is_truncated": bool(is_truncated),
+        "permanent_storage_hwm_date": permanent_storage_hwm_date or "",
     }
 
 

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -264,6 +264,16 @@ def _require_invoice_query_date_type(value: str) -> m.InvoiceQueryDateType:
     )
 
 
+def _require_export_sort_order(value: str) -> str:
+    if value == "Asc":
+        return value
+    raise CliError(
+        "Invalid sort order for export.",
+        ExitCode.VALIDATION_ERROR,
+        "For `ksef export run` use --sort-order Asc.",
+    )
+
+
 def _require_encryption_info(encryption: EncryptionData) -> m.EncryptionInfo:
     encryption_info = getattr(encryption, "encryption_info", None)
     if encryption_info is None:
@@ -1246,7 +1256,10 @@ def run_export(
     base_url: str,
     date_from: str | None,
     date_to: str | None,
+    date_type: str = m.InvoiceQueryDateType.ISSUE.value,
+    sort_order: str = "Asc",
     subject_type: str,
+    restrict_to_permanent_storage_hwm_date: bool = False,
     only_metadata: bool = False,
     poll_interval: float,
     max_attempts: int,
@@ -1255,6 +1268,8 @@ def run_export(
     access_token = _require_access_token(profile)
     _validate_polling_options(poll_interval, max_attempts)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
+    date_type_enum = _require_invoice_query_date_type(date_type)
+    normalized_sort_order = _require_export_sort_order(sort_order)
     out_dir = Path(out).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1272,9 +1287,10 @@ def run_export(
             filters=m.InvoiceQueryFilters(
                 subject_type=_require_invoice_query_subject_type(subject_type),
                 date_range=m.InvoiceQueryDateRange(
-                    date_type=m.InvoiceQueryDateType.ISSUE,
+                    date_type=date_type_enum,
                     from_=from_iso,
                     to=to_iso,
+                    restrict_to_permanent_storage_hwm_date=restrict_to_permanent_storage_hwm_date,
                 ),
             ),
         )
@@ -1336,6 +1352,9 @@ def run_export(
         "out_dir": str(out_dir),
         "from": from_iso,
         "to": to_iso,
+        "date_type": date_type_enum.value,
+        "sort_order": normalized_sort_order,
+        "restrict_to_permanent_storage_hwm_date": restrict_to_permanent_storage_hwm_date,
     }
 
 

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -290,16 +290,6 @@ def _require_invoice_query_date_type(value: str) -> m.InvoiceQueryDateType:
     )
 
 
-def _require_export_sort_order(value: str) -> str:
-    if value == "Asc":
-        return value
-    raise CliError(
-        "Invalid sort order for export.",
-        ExitCode.VALIDATION_ERROR,
-        "For `ksef export run` use --sort-order Asc.",
-    )
-
-
 def _require_encryption_info(encryption: EncryptionData) -> m.EncryptionInfo:
     encryption_info = getattr(encryption, "encryption_info", None)
     if encryption_info is None:
@@ -352,6 +342,26 @@ def _extract_invoice_query_metadata(response: Any) -> tuple[bool, bool, str, str
         or ""
     )
     return has_more, is_truncated, permanent_storage_hwm_date, continuation_token
+
+
+def _merge_permanent_storage_hwm_date(current: str, candidate: str) -> str:
+    current_value = (current or "").strip()
+    candidate_value = (candidate or "").strip()
+    if not candidate_value:
+        return current_value
+    if not current_value:
+        return candidate_value
+
+    current_normalized = _normalize_invoice_sort_value(current_value)
+    candidate_normalized = _normalize_invoice_sort_value(candidate_value)
+    if not current_normalized:
+        return candidate_value
+    if not candidate_normalized:
+        return current_value
+
+    if candidate_normalized < current_normalized:
+        return candidate_value
+    return current_value
 
 
 def _normalize_invoice_sort_value(value: Any) -> str:
@@ -443,10 +453,7 @@ def _query_all_invoice_subject_types(
     sort_order: str,
 ) -> dict[str, Any]:
     normalized_offset = max(page_offset, 0)
-    if page_size <= 0:
-        limit = None
-    else:
-        limit = normalized_offset + page_size + 1
+    limit = None if page_size <= 0 else normalized_offset + page_size + 1
     reverse_order = sort_order.casefold() == "desc"
 
     stream_states: list[dict[str, Any]] = [
@@ -461,12 +468,10 @@ def _query_all_invoice_subject_types(
     ]
     aggregated: list[Any] = []
     dedupe_keys: set[str] = set()
-    aggregated_has_more = False
     aggregated_is_truncated = False
     permanent_storage_hwm_date = ""
 
     def _load_next_page(state: dict[str, Any]) -> None:
-        nonlocal aggregated_has_more
         nonlocal aggregated_is_truncated
         nonlocal permanent_storage_hwm_date
 
@@ -486,15 +491,16 @@ def _query_all_invoice_subject_types(
         )
         invoices = _extract_invoice_items(response)
         has_more_raw = _get_value(response, "has_more", "hasMore", None)
-        has_more, is_truncated, hwm_date, _ = _extract_invoice_query_metadata(response)
+        _, is_truncated, hwm_date, _ = _extract_invoice_query_metadata(response)
         state["invoices"] = invoices
         state["index"] = 0
         state["next_offset"] += max(page_size, 0)
 
-        aggregated_has_more = aggregated_has_more or has_more
         aggregated_is_truncated = aggregated_is_truncated or is_truncated
-        if hwm_date and not permanent_storage_hwm_date:
-            permanent_storage_hwm_date = hwm_date
+        permanent_storage_hwm_date = _merge_permanent_storage_hwm_date(
+            permanent_storage_hwm_date,
+            hwm_date,
+        )
 
         if not invoices:
             state["exhausted"] = True
@@ -523,9 +529,21 @@ def _query_all_invoice_subject_types(
         if not available_states:
             break
         selected_state = (
-            max(available_states, key=lambda state: _invoice_sort_key(state["invoices"][state["index"]], date_type=date_type))
+            max(
+                available_states,
+                key=lambda state: _invoice_sort_key(
+                    state["invoices"][state["index"]],
+                    date_type=date_type,
+                ),
+            )
             if reverse_order
-            else min(available_states, key=lambda state: _invoice_sort_key(state["invoices"][state["index"]], date_type=date_type))
+            else min(
+                available_states,
+                key=lambda state: _invoice_sort_key(
+                    state["invoices"][state["index"]],
+                    date_type=date_type,
+                ),
+            )
         )
         invoice = selected_state["invoices"][selected_state["index"]]
         selected_state["index"] += 1
@@ -542,8 +560,6 @@ def _query_all_invoice_subject_types(
         page_end = normalized_offset + page_size
         items = aggregated[normalized_offset:page_end]
         has_more = len(aggregated) > page_end
-        if not has_more and aggregated_has_more and len(aggregated) >= page_end:
-            has_more = True
 
     return {
         "items": items,
@@ -1385,7 +1401,6 @@ def run_export(
     date_from: str | None,
     date_to: str | None,
     date_type: str = m.InvoiceQueryDateType.ISSUE.value,
-    sort_order: str = "Asc",
     subject_type: str,
     restrict_to_permanent_storage_hwm_date: bool = False,
     only_metadata: bool = False,
@@ -1397,7 +1412,6 @@ def run_export(
     _validate_polling_options(poll_interval, max_attempts)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
     date_type_enum = _require_invoice_query_date_type(date_type)
-    normalized_sort_order = _require_export_sort_order(sort_order)
     out_dir = Path(out).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1481,7 +1495,6 @@ def run_export(
         "from": from_iso,
         "to": to_iso,
         "date_type": date_type_enum.value,
-        "sort_order": normalized_sort_order,
         "restrict_to_permanent_storage_hwm_date": restrict_to_permanent_storage_hwm_date,
     }
 

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 import json
 import time
 from contextlib import suppress
@@ -112,8 +113,33 @@ def _normalize_date_range(date_from: str | None, date_to: str | None) -> tuple[s
             ExitCode.VALIDATION_ERROR,
             "--from must be earlier than or equal to --to.",
         )
+    max_to_dt = _add_months(from_dt, 3)
+    if to_dt.date() > max_to_dt.date():
+        raise CliError(
+            "Date range exceeds KSeF limit.",
+            ExitCode.VALIDATION_ERROR,
+            "Use a maximum range of 3 months between --from and --to.",
+        )
 
     return from_dt.isoformat().replace("+00:00", "Z"), to_dt.isoformat().replace("+00:00", "Z")
+
+
+def _add_months(value: datetime, months: int) -> datetime:
+    month_index = value.month - 1 + months
+    target_year = value.year + month_index // 12
+    target_month = month_index % 12 + 1
+    target_day = min(value.day, calendar.monthrange(target_year, target_month)[1])
+    return value.replace(year=target_year, month=target_month, day=target_day)
+
+
+def _require_invoice_query_page_size(value: int) -> int:
+    if 10 <= value <= 250:
+        return value
+    raise CliError(
+        "Invalid page size.",
+        ExitCode.VALIDATION_ERROR,
+        "--page-size must be between 10 and 250.",
+    )
 
 
 def _resolve_output_path(
@@ -844,6 +870,7 @@ def list_invoices(
     sort_order: str,
 ) -> dict[str, Any]:
     access_token = _require_access_token(profile)
+    normalized_page_size = _require_invoice_query_page_size(page_size)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
     resolved_date_type = _require_invoice_query_date_type(date_type)
 
@@ -859,7 +886,7 @@ def list_invoices(
                 date_type=resolved_date_type,
                 from_iso=from_iso,
                 to_iso=to_iso,
-                page_size=page_size,
+                page_size=normalized_page_size,
                 page_offset=page_offset,
                 sort_order=sort_order,
             )
@@ -875,7 +902,7 @@ def list_invoices(
                 date_type=resolved_date_type,
                 from_iso=from_iso,
                 to_iso=to_iso,
-                page_size=page_size,
+                page_size=normalized_page_size,
                 page_offset=page_offset,
                 sort_order=sort_order,
             )

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -354,10 +354,6 @@ def _merge_permanent_storage_hwm_date(current: str, candidate: str) -> str:
 
     current_normalized = _normalize_invoice_sort_value(current_value)
     candidate_normalized = _normalize_invoice_sort_value(candidate_value)
-    if not current_normalized:
-        return candidate_value
-    if not candidate_normalized:
-        return current_value
 
     if candidate_normalized < current_normalized:
         return candidate_value
@@ -475,7 +471,7 @@ def _query_all_invoice_subject_types(
         nonlocal aggregated_is_truncated
         nonlocal permanent_storage_hwm_date
 
-        if state["exhausted"]:
+        if state["exhausted"]:  # pragma: no cover - defensive guard
             return
 
         response = _query_invoice_metadata_page(

--- a/tests/cli/integration/test_export_run.py
+++ b/tests/cli/integration/test_export_run.py
@@ -15,6 +15,7 @@ def _json_output(text: str) -> dict:
 def test_export_run_help(runner) -> None:
     result = runner.invoke(app, ["export", "run", "--help"])
     assert result.exit_code == 0
+    assert "--sort-order" not in result.stdout
 
 
 def test_export_run_success(runner, monkeypatch, tmp_path) -> None:
@@ -63,3 +64,11 @@ def test_export_run_validation_error_exit(runner, monkeypatch, tmp_path) -> None
     )
     result = runner.invoke(app, ["export", "run", "--out", str(tmp_path)])
     assert result.exit_code == int(ExitCode.VALIDATION_ERROR)
+
+
+def test_export_run_rejects_removed_sort_order_option(runner, tmp_path) -> None:
+    result = runner.invoke(
+        app,
+        ["export", "run", "--sort-order", "Asc", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0

--- a/tests/cli/integration/test_invoice_list.py
+++ b/tests/cli/integration/test_invoice_list.py
@@ -46,7 +46,7 @@ def test_invoice_list_success(runner, monkeypatch) -> None:
             "--date-type",
             "Issue",
             "--page-size",
-            "5",
+            "10",
             "--page-offset",
             "10",
             "--sort-order",
@@ -57,7 +57,7 @@ def test_invoice_list_success(runner, monkeypatch) -> None:
     assert result.exit_code == 0
     assert seen["profile"] == "demo"
     assert seen["subject_type"] == "Subject2"
-    assert seen["page_size"] == 5
+    assert seen["page_size"] == 10
     assert seen["page_offset"] == 10
     assert seen["sort_order"] == "Asc"
     assert "invoice.list" in result.stdout
@@ -130,3 +130,15 @@ def test_invoice_list_json_validation_error_envelope(runner, monkeypatch) -> Non
 def test_invoice_list_invalid_sort_order_is_rejected(runner) -> None:
     result = runner.invoke(app, ["invoice", "list", "--sort-order", "WRONG"])
     assert result.exit_code == int(ExitCode.VALIDATION_ERROR)
+
+
+def test_invoice_list_rejects_page_size_below_openapi_min(runner) -> None:
+    result = runner.invoke(app, ["invoice", "list", "--page-size", "9"])
+    assert result.exit_code == 2
+    assert "10<=x<=250" in result.stdout
+
+
+def test_invoice_list_rejects_page_size_above_openapi_max(runner) -> None:
+    result = runner.invoke(app, ["invoice", "list", "--page-size", "251"])
+    assert result.exit_code == 2
+    assert "10<=x<=250" in result.stdout

--- a/tests/cli/integration/test_invoice_list.py
+++ b/tests/cli/integration/test_invoice_list.py
@@ -140,3 +140,8 @@ def test_invoice_list_rejects_page_size_below_openapi_min(runner) -> None:
 def test_invoice_list_rejects_page_size_above_openapi_max(runner) -> None:
     result = runner.invoke(app, ["invoice", "list", "--page-size", "251"])
     assert result.exit_code == 2
+
+
+def test_invoice_list_rejects_negative_page_offset(runner) -> None:
+    result = runner.invoke(app, ["invoice", "list", "--page-offset", "-1"])
+    assert result.exit_code == 2

--- a/tests/cli/integration/test_invoice_list.py
+++ b/tests/cli/integration/test_invoice_list.py
@@ -135,10 +135,8 @@ def test_invoice_list_invalid_sort_order_is_rejected(runner) -> None:
 def test_invoice_list_rejects_page_size_below_openapi_min(runner) -> None:
     result = runner.invoke(app, ["invoice", "list", "--page-size", "9"])
     assert result.exit_code == 2
-    assert "10<=x<=250" in result.stdout
 
 
 def test_invoice_list_rejects_page_size_above_openapi_max(runner) -> None:
     result = runner.invoke(app, ["invoice", "list", "--page-size", "251"])
     assert result.exit_code == 2
-    assert "10<=x<=250" in result.stdout

--- a/tests/cli/unit/test_auth_manager.py
+++ b/tests/cli/unit/test_auth_manager.py
@@ -186,6 +186,43 @@ def test_discover_current_token_reference_number_returns_none_for_multiple_match
     assert result is None
 
 
+def test_collect_active_token_reference_numbers_uses_pagination_without_early_stop(
+    monkeypatch,
+) -> None:
+    calls: list[str | None] = []
+
+    def _list_tokens(**kwargs) -> m.QueryTokensResponse:
+        continuation_token = kwargs.get("continuation_token")
+        calls.append(continuation_token)
+        if continuation_token is None:
+            return m.QueryTokensResponse(
+                tokens=[_token_list_item(reference_number="REF-123")],
+                continuation_token="next",
+            )
+        if continuation_token == "next":
+            return m.QueryTokensResponse(
+                tokens=[_token_list_item(reference_number="REF-456")],
+                continuation_token=None,
+            )
+        raise AssertionError(f"Unexpected continuation_token: {continuation_token}")
+
+    client = SimpleNamespace(tokens=SimpleNamespace(list_tokens=_list_tokens))
+    monkeypatch.setattr(
+        manager,
+        "_profile_context",
+        lambda profile: ("https://api-demo.ksef.mf.gov.pl", "Nip", "5265877635"),
+    )
+
+    result = manager._collect_active_token_reference_numbers(
+        client=client,
+        access_token="acc",
+        profile="demo",
+    )
+
+    assert result == {"REF-123", "REF-456"}
+    assert calls == [None, "next"]
+
+
 def test_discover_current_token_reference_number_stops_on_repeated_continuation_token(
     monkeypatch,
 ) -> None:
@@ -917,9 +954,10 @@ def test_revoke_self_token_requires_unambiguous_reference_number(monkeypatch) ->
     monkeypatch.setattr(manager, "get_cached_metadata", lambda profile: {"method": "token"})
     monkeypatch.setattr(
         manager,
-        "_discover_current_token_reference_number",
-        lambda **kwargs: None,
+        "_collect_active_token_reference_numbers",
+        lambda **kwargs: set(),
     )
+    monkeypatch.setattr(manager, "create_client", lambda base_url: _FakeClient())
 
     with pytest.raises(CliError) as exc:
         manager.revoke_self_token(
@@ -928,3 +966,44 @@ def test_revoke_self_token_requires_unambiguous_reference_number(monkeypatch) ->
         )
 
     assert exc.value.code == ExitCode.AUTH_ERROR
+
+
+def test_revoke_self_token_raises_explicit_error_for_multiple_matching_tokens(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(manager, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(manager, "get_cached_metadata", lambda profile: {"method": "token"})
+
+    class _FakeListClient(_FakeClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.tokens = SimpleNamespace(
+                list_tokens=lambda **kwargs: m.QueryTokensResponse(
+                    tokens=[
+                        _token_list_item(reference_number="REF-123"),
+                        _token_list_item(reference_number="REF-456"),
+                    ],
+                    continuation_token=None,
+                ),
+                revoke_token=lambda reference_number, access_token: pytest.fail(
+                    "revoke_token should not be called for ambiguous references"
+                ),
+            )
+
+    monkeypatch.setattr(
+        manager,
+        "_profile_context",
+        lambda profile: ("https://api-demo.ksef.mf.gov.pl", "Nip", "5265877635"),
+    )
+    monkeypatch.setattr(manager, "create_client", lambda base_url: _FakeListClient())
+
+    with pytest.raises(CliError) as exc:
+        manager.revoke_self_token(
+            profile="demo",
+            base_url="https://api-demo.ksef.mf.gov.pl",
+        )
+
+    assert exc.value.code == ExitCode.AUTH_ERROR
+    assert "multiple active tokens match the profile context" in str(exc.value)
+    assert "REF-123" in str(exc.value)
+    assert "REF-456" in str(exc.value)

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -71,6 +71,9 @@ def test_list_invoices_success(monkeypatch) -> None:
 
     assert result["count"] == 1
     assert result["continuation_token"] == "ct"
+    assert result["has_more"] is True
+    assert result["is_truncated"] is False
+    assert result["permanent_storage_hwm_date"] == ""
     assert seen["page_size"] == 10
     assert seen["sort_order"] == "Desc"
     payload = seen["payload"]
@@ -1214,6 +1217,9 @@ def test_list_invoices_uses_default_from_and_invoice_list_key(monkeypatch) -> No
     )
     assert result["count"] == 1
     assert result["items"][0]["ksefReferenceNumber"] == "KSEF-X"
+    assert result["has_more"] is False
+    assert result["is_truncated"] is False
+    assert result["permanent_storage_hwm_date"] == ""
 
 
 def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatch) -> None:
@@ -1224,11 +1230,14 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
             "invoices": [
                 {"ksefNumber": "KSEF-2", "issueDate": "2026-01-03T00:00:00Z"},
                 {"ksefNumber": "KSEF-DUP", "issueDate": "2026-01-02T00:00:00Z"},
-            ]
+            ],
+            "hasMore": False,
         },
         ("Subject1", 2): {"invoices": []},
         ("Subject2", 0): {
-            "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-04T00:00:00Z"}]
+            "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-04T00:00:00Z"}],
+            "isTruncated": True,
+            "permanentStorageHwmDate": "2026-01-31T23:59:59Z",
         },
         ("Subject3", 0): {
             "invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]
@@ -1267,7 +1276,6 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
 
     assert seen_calls == [
         ("Subject1", 0, 2),
-        ("Subject1", 2, 2),
         ("Subject2", 0, 2),
         ("Subject3", 0, 2),
         ("SubjectAuthorized", 0, 2),
@@ -1275,6 +1283,9 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
     assert result["count"] == 2
     assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-2", "KSEF-DUP"]
     assert result["continuation_token"] == ""
+    assert result["has_more"] is True
+    assert result["is_truncated"] is True
+    assert result["permanent_storage_hwm_date"] == "2026-01-31T23:59:59Z"
 
 
 def test_invoice_sort_value_handles_empty_invalid_and_naive_datetime() -> None:
@@ -1301,16 +1312,16 @@ def test_query_all_invoice_subject_types_handles_negative_offset_and_unbounded_p
     monkeypatch,
 ) -> None:
     responses = {
-        ("Subject1", 0): [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}],
-        ("Subject2", 0): [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}],
-        ("Subject3", 0): [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}],
-        ("SubjectAuthorized", 0): [],
+        ("Subject1", 0): {"invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]},
+        ("Subject2", 0): {"invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}]},
+        ("Subject3", 0): {"invoices": [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}]},
+        ("SubjectAuthorized", 0): {"invoices": []},
     }
 
     def _fake_query_page(**kwargs):
         subject_type = kwargs["subject_type"].value
         page_offset = kwargs["page_offset"]
-        return {"invoices": responses[(subject_type, page_offset)]}
+        return responses[(subject_type, page_offset)]
 
     monkeypatch.setattr(adapters, "_query_invoice_metadata_page", _fake_query_page)
 
@@ -1325,7 +1336,10 @@ def test_query_all_invoice_subject_types_handles_negative_offset_and_unbounded_p
         sort_order="Asc",
     )
 
-    assert [item["ksefNumber"] for item in result] == ["KSEF-1", "KSEF-2", "KSEF-3"]
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-1", "KSEF-2", "KSEF-3"]
+    assert result["has_more"] is False
+    assert result["is_truncated"] is False
+    assert result["permanent_storage_hwm_date"] == ""
 
 
 def test_resolve_output_path_for_plain_path_segment() -> None:

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -151,6 +151,113 @@ def test_list_invoices_rejects_reverse_date_range(monkeypatch) -> None:
     assert exc.value.code == ExitCode.VALIDATION_ERROR
 
 
+def test_list_invoices_rejects_date_range_longer_than_3_months(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(invoices=SimpleNamespace()),
+    )
+
+    with pytest.raises(CliError) as exc:
+        adapters.list_invoices(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-04-02",
+            subject_type="Subject1",
+            date_type="Issue",
+            page_size=10,
+            page_offset=0,
+            sort_order="Desc",
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "3 months" in (exc.value.hint or "")
+
+
+def test_list_invoices_accepts_date_range_exactly_3_months(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class _Invoices:
+        def query_invoice_metadata(self, payload, **kwargs):
+            _ = payload
+            seen.update(kwargs)
+            return {"invoices": []}
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(invoices=_Invoices()),
+    )
+
+    result = adapters.list_invoices(
+        profile="demo",
+        base_url="https://example.invalid",
+        date_from="2026-01-01",
+        date_to="2026-04-01",
+        subject_type="Subject1",
+        date_type="Issue",
+        page_size=10,
+        page_offset=0,
+        sort_order="Desc",
+    )
+
+    assert result["count"] == 0
+    assert seen["page_size"] == 10
+
+
+def test_list_invoices_rejects_page_size_below_openapi_min(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call client")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        adapters.list_invoices(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            subject_type="Subject1",
+            date_type="Issue",
+            page_size=9,
+            page_offset=0,
+            sort_order="Desc",
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "10 and 250" in (exc.value.hint or "")
+
+
+def test_list_invoices_rejects_page_size_above_openapi_max(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call client")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        adapters.list_invoices(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            subject_type="Subject1",
+            date_type="Issue",
+            page_size=251,
+            page_offset=0,
+            sort_order="Desc",
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "10 and 250" in (exc.value.hint or "")
+
+
 def test_list_invoices_rejects_invalid_subject_type(monkeypatch) -> None:
     monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
     monkeypatch.setattr(
@@ -1308,7 +1415,7 @@ def test_invoice_identity_key_falls_back_to_serialized_payload_and_repr() -> Non
     assert "_PlainObject object" in repr_key
 
 
-def test_query_all_invoice_subject_types_handles_negative_offset_and_unbounded_page_size(
+def test_query_all_invoice_subject_types_handles_negative_offset_and_bounded_page_size(
     monkeypatch,
 ) -> None:
     responses = {
@@ -1331,7 +1438,7 @@ def test_query_all_invoice_subject_types_handles_negative_offset_and_unbounded_p
         date_type=m.InvoiceQueryDateType.ISSUE,
         from_iso="2026-01-01T00:00:00Z",
         to_iso="2026-01-31T23:59:59Z",
-        page_size=0,
+        page_size=10,
         page_offset=-5,
         sort_order="Asc",
     )

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -2666,7 +2667,7 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
 
 
 def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
-    seen: dict[str, object] = {}
+    seen: dict[str, Any] = {}
 
     class _Renderer:
         def success(self, *, command, profile, data):
@@ -2684,7 +2685,7 @@ def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
     )
 
     export_cmd.export_run(
-        ctx=SimpleNamespace(),
+        ctx=cast(Any, SimpleNamespace()),
         date_from="2026-01-01",
         date_to="2026-01-31",
         date_type="PermanentStorage",

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from ksef_client import models as m
+from ksef_client.cli.commands import export_cmd
 from ksef_client.cli.errors import CliError
 from ksef_client.cli.exit_codes import ExitCode
 from ksef_client.cli.sdk import adapters
@@ -2186,9 +2188,14 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
     assert result["reference_number"] == "EXP-OK"
     assert result["metadata_count"] == 1
     assert result["only_metadata"] is False
+    assert result["date_type"] == "Issue"
+    assert result["sort_order"] == "Asc"
+    assert result["restrict_to_permanent_storage_hwm_date"] is False
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.only_metadata is False
+    assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.ISSUE
+    assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is False
     assert (tmp_path / "_metadata.json").exists()
     assert (tmp_path / "a.xml").read_text(encoding="utf-8") == "<xml/>"
 
@@ -2278,11 +2285,148 @@ def test_run_export_only_metadata_success(monkeypatch, tmp_path) -> None:
     assert result["metadata_count"] == 1
     assert result["xml_files_count"] == 0
     assert result["only_metadata"] is True
+    assert result["sort_order"] == "Asc"
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.only_metadata is True
     assert (tmp_path / "_metadata.json").exists()
     assert list(tmp_path.glob("*.xml")) == []
+
+
+def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _Invoices:
+        def export_invoices(self, payload, access_token):
+            seen["payload"] = payload
+            seen["access_token"] = access_token
+            return {"referenceNumber": "EXP-HWM"}
+
+        def get_export_status(self, reference_number, access_token):
+            _ = (reference_number, access_token)
+            return {
+                "status": {"code": 200, "description": "Done"},
+                "package": {
+                    "invoiceCount": 0,
+                    "size": 0,
+                    "isTruncated": False,
+                    "parts": [],
+                },
+            }
+
+    class _FakeExportWorkflow:
+        def __init__(self, invoices_client, http_client):
+            _ = (invoices_client, http_client)
+
+        def download_and_process_package(self, package, encryption_data):
+            _ = (package, encryption_data)
+            return SimpleNamespace(metadata_summaries=[], invoice_xml_files={})
+
+    fake_encryption = SimpleNamespace(
+        key=b"k",
+        iv=b"i",
+        encryption_info=SimpleNamespace(
+            encrypted_symmetric_key="enc",
+            initialization_vector="iv",
+        ),
+    )
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            invoices=_Invoices(), security=_Security(), http_client=SimpleNamespace()
+        ),
+    )
+    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "ExportWorkflow", _FakeExportWorkflow)
+    monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
+
+    out_dir = Path("build_test_export_hwm")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = adapters.run_export(
+        profile="demo",
+        base_url="https://example.invalid",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        date_type="PermanentStorage",
+        sort_order="Asc",
+        subject_type="Subject1",
+        restrict_to_permanent_storage_hwm_date=True,
+        poll_interval=0.01,
+        max_attempts=2,
+        out=str(out_dir),
+    )
+
+    assert result["reference_number"] == "EXP-HWM"
+    assert result["date_type"] == "PermanentStorage"
+    assert result["sort_order"] == "Asc"
+    assert result["restrict_to_permanent_storage_hwm_date"] is True
+    payload = seen["payload"]
+    assert isinstance(payload, m.InvoiceExportRequest)
+    assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.PERMANENTSTORAGE
+    assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is True
+
+
+def test_run_export_rejects_sort_order_other_than_asc(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    with pytest.raises(CliError) as exc:
+        adapters.run_export(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            date_type="Issue",
+            sort_order="Desc",
+            subject_type="Subject1",
+            poll_interval=0.01,
+            max_attempts=1,
+            out=".",
+        )
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+
+
+def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class _Renderer:
+        def success(self, *, command, profile, data):
+            seen["result"] = {"command": command, "profile": profile, "data": data}
+
+    monkeypatch.setattr(export_cmd, "require_context", lambda ctx: SimpleNamespace(profile="demo"))
+    monkeypatch.setattr(export_cmd, "get_renderer", lambda cli_ctx: _Renderer())
+    monkeypatch.setattr(export_cmd, "profile_label", lambda cli_ctx: "demo")
+    monkeypatch.setattr(export_cmd, "require_profile", lambda cli_ctx: "demo")
+    monkeypatch.setattr(export_cmd, "resolve_base_url", lambda value, profile: value or "https://example.invalid")
+    monkeypatch.setattr(
+        export_cmd,
+        "run_export",
+        lambda **kwargs: seen.setdefault("kwargs", kwargs) or {"ok": True},
+    )
+
+    export_cmd.export_run(
+        ctx=SimpleNamespace(),
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        date_type="PermanentStorage",
+        sort_order="Asc",
+        subject_type="Subject1",
+        restrict_to_permanent_storage_hwm_date=True,
+        only_metadata=False,
+        poll_interval=1.0,
+        max_attempts=10,
+        out=".",
+        base_url="https://example.invalid",
+    )
+
+    assert seen["kwargs"]["date_type"] == "PermanentStorage"
+    assert seen["kwargs"]["sort_order"] == "Asc"
+    assert seen["kwargs"]["restrict_to_permanent_storage_hwm_date"] is True
 
 
 def test_run_export_missing_reference_and_package(monkeypatch, tmp_path) -> None:

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1554,6 +1554,76 @@ def test_query_all_invoice_subject_types_has_more_false_when_followup_pages_only
     assert result["has_more"] is False
 
 
+def test_query_all_invoice_subject_types_page_size_zero_returns_unbounded_slice(
+    monkeypatch,
+) -> None:
+    responses = {
+        ("Subject1", 0): {
+            "invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]
+        },
+        ("Subject2", 0): {"invoices": []},
+        ("Subject3", 0): {"invoices": []},
+        ("SubjectAuthorized", 0): {"invoices": []},
+    }
+
+    def _fake_query_page(**kwargs):
+        subject_type = kwargs["subject_type"].value
+        page_offset = kwargs["page_offset"]
+        return responses[(subject_type, page_offset)]
+
+    monkeypatch.setattr(adapters, "_query_invoice_metadata_page", _fake_query_page)
+
+    result = adapters._query_all_invoice_subject_types(
+        client=object(),
+        access_token="token",
+        date_type=m.InvoiceQueryDateType.ISSUE,
+        from_iso="2026-01-01T00:00:00Z",
+        to_iso="2026-01-31T23:59:59Z",
+        page_size=0,
+        page_offset=0,
+        sort_order="Asc",
+    )
+
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-1"]
+    assert result["has_more"] is False
+
+
+def test_query_all_invoice_subject_types_stops_at_limit_before_deeper_paging(monkeypatch) -> None:
+    responses = {
+        ("Subject1", 0): {
+            "invoices": [
+                {"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"},
+                {"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"},
+                {"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"},
+            ]
+        },
+        ("Subject2", 0): {"invoices": []},
+        ("Subject3", 0): {"invoices": []},
+        ("SubjectAuthorized", 0): {"invoices": []},
+    }
+
+    def _fake_query_page(**kwargs):
+        subject_type = kwargs["subject_type"].value
+        page_offset = kwargs["page_offset"]
+        return responses[(subject_type, page_offset)]
+
+    monkeypatch.setattr(adapters, "_query_invoice_metadata_page", _fake_query_page)
+
+    result = adapters._query_all_invoice_subject_types(
+        client=object(),
+        access_token="token",
+        date_type=m.InvoiceQueryDateType.ISSUE,
+        from_iso="2026-01-01T00:00:00Z",
+        to_iso="2026-01-31T23:59:59Z",
+        page_size=1,
+        page_offset=0,
+        sort_order="Asc",
+    )
+
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-1"]
+    assert result["has_more"] is True
+
+
 def test_resolve_output_path_for_plain_path_segment() -> None:
     path = adapters._resolve_output_path("artifacts", default_filename="out.xml")
     assert path.as_posix().endswith("artifacts")

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1387,11 +1387,64 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
         ("SubjectAuthorized", 0, 10),
     ]
     assert result["count"] == 4
-    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-3", "KSEF-2", "KSEF-DUP", "KSEF-1"]
+    assert [item["ksefNumber"] for item in result["items"]] == [
+        "KSEF-3",
+        "KSEF-2",
+        "KSEF-DUP",
+        "KSEF-1",
+    ]
     assert result["continuation_token"] == ""
     assert result["has_more"] is False
     assert result["is_truncated"] is True
     assert result["permanent_storage_hwm_date"] == "2026-01-31T23:59:59Z"
+
+
+def test_list_invoices_without_subject_type_aggregates_lowest_hwm_date(monkeypatch) -> None:
+    responses = {
+        ("Subject1", 0): {
+            "invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}],
+            "permanentStorageHwmDate": "2026-02-10T00:00:00Z",
+        },
+        ("Subject2", 0): {
+            "invoices": [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}],
+            "permanentStorageHwmDate": "2026-01-15T00:00:00Z",
+        },
+        ("Subject3", 0): {
+            "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}],
+            "permanentStorageHwmDate": "2026-01-20T00:00:00Z",
+        },
+        ("SubjectAuthorized", 0): {
+            "invoices": [{"ksefNumber": "KSEF-4", "issueDate": "2026-01-04T00:00:00Z"}]
+        },
+    }
+
+    class _Invoices:
+        def query_invoice_metadata(self, payload, **kwargs):
+            subject_type = payload.subject_type.value
+            page_offset = int(kwargs.get("page_offset", 0) or 0)
+            return responses[(subject_type, page_offset)]
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(invoices=_Invoices()),
+    )
+
+    result = adapters.list_invoices(
+        profile="demo",
+        base_url="https://example.invalid",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        subject_type=None,
+        date_type="Issue",
+        page_size=10,
+        page_offset=0,
+        sort_order="Asc",
+    )
+
+    assert result["count"] == 4
+    assert result["permanent_storage_hwm_date"] == "2026-01-15T00:00:00Z"
 
 
 def test_invoice_sort_value_handles_empty_invalid_and_naive_datetime() -> None:
@@ -1418,9 +1471,15 @@ def test_query_all_invoice_subject_types_handles_negative_offset_and_bounded_pag
     monkeypatch,
 ) -> None:
     responses = {
-        ("Subject1", 0): {"invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]},
-        ("Subject2", 0): {"invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}]},
-        ("Subject3", 0): {"invoices": [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}]},
+        ("Subject1", 0): {
+            "invoices": [{"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"}]
+        },
+        ("Subject2", 0): {
+            "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-03T00:00:00Z"}]
+        },
+        ("Subject3", 0): {
+            "invoices": [{"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"}]
+        },
         ("SubjectAuthorized", 0): {"invoices": []},
     }
 
@@ -1446,6 +1505,53 @@ def test_query_all_invoice_subject_types_handles_negative_offset_and_bounded_pag
     assert result["has_more"] is False
     assert result["is_truncated"] is False
     assert result["permanent_storage_hwm_date"] == ""
+
+
+def test_query_all_invoice_subject_types_has_more_false_when_followup_pages_only_duplicate(
+    monkeypatch,
+) -> None:
+    seen_calls: list[tuple[str, int]] = []
+    responses = {
+        ("Subject1", 0): {
+            "invoices": [
+                {"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"},
+                {"ksefNumber": "KSEF-2", "issueDate": "2026-01-02T00:00:00Z"},
+            ],
+            "hasMore": True,
+        },
+        ("Subject1", 2): {
+            "invoices": [
+                {"ksefNumber": "KSEF-1", "issueDate": "2026-01-01T00:00:00Z"},
+            ],
+            "hasMore": False,
+        },
+        ("Subject2", 0): {"invoices": []},
+        ("Subject3", 0): {"invoices": []},
+        ("SubjectAuthorized", 0): {"invoices": []},
+    }
+
+    def _fake_query_page(**kwargs):
+        subject_type = kwargs["subject_type"].value
+        page_offset = kwargs["page_offset"]
+        seen_calls.append((subject_type, page_offset))
+        return responses[(subject_type, page_offset)]
+
+    monkeypatch.setattr(adapters, "_query_invoice_metadata_page", _fake_query_page)
+
+    result = adapters._query_all_invoice_subject_types(
+        client=object(),
+        access_token="token",
+        date_type=m.InvoiceQueryDateType.ISSUE,
+        from_iso="2026-01-01T00:00:00Z",
+        to_iso="2026-01-31T23:59:59Z",
+        page_size=2,
+        page_offset=0,
+        sort_order="Asc",
+    )
+
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-1", "KSEF-2"]
+    assert ("Subject1", 2) in seen_calls
+    assert result["has_more"] is False
 
 
 def test_resolve_output_path_for_plain_path_segment() -> None:
@@ -2309,7 +2415,6 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
     assert result["metadata_count"] == 1
     assert result["only_metadata"] is False
     assert result["date_type"] == "Issue"
-    assert result["sort_order"] == "Asc"
     assert result["restrict_to_permanent_storage_hwm_date"] is False
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
@@ -2405,7 +2510,6 @@ def test_run_export_only_metadata_success(monkeypatch, tmp_path) -> None:
     assert result["metadata_count"] == 1
     assert result["xml_files_count"] == 0
     assert result["only_metadata"] is True
-    assert result["sort_order"] == "Asc"
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.only_metadata is True
@@ -2475,7 +2579,6 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
         date_from="2026-01-01",
         date_to="2026-01-31",
         date_type="PermanentStorage",
-        sort_order="Asc",
         subject_type="Subject1",
         restrict_to_permanent_storage_hwm_date=True,
         poll_interval=0.01,
@@ -2485,30 +2588,11 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
 
     assert result["reference_number"] == "EXP-HWM"
     assert result["date_type"] == "PermanentStorage"
-    assert result["sort_order"] == "Asc"
     assert result["restrict_to_permanent_storage_hwm_date"] is True
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.PERMANENTSTORAGE
     assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is True
-
-
-def test_run_export_rejects_sort_order_other_than_asc(monkeypatch) -> None:
-    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
-    with pytest.raises(CliError) as exc:
-        adapters.run_export(
-            profile="demo",
-            base_url="https://example.invalid",
-            date_from="2026-01-01",
-            date_to="2026-01-31",
-            date_type="Issue",
-            sort_order="Desc",
-            subject_type="Subject1",
-            poll_interval=0.01,
-            max_attempts=1,
-            out=".",
-        )
-    assert exc.value.code == ExitCode.VALIDATION_ERROR
 
 
 def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
@@ -2534,7 +2618,6 @@ def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
         date_from="2026-01-01",
         date_to="2026-01-31",
         date_type="PermanentStorage",
-        sort_order="Asc",
         subject_type="Subject1",
         restrict_to_permanent_storage_hwm_date=True,
         only_metadata=False,
@@ -2545,8 +2628,8 @@ def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:
     )
 
     assert seen["kwargs"]["date_type"] == "PermanentStorage"
-    assert seen["kwargs"]["sort_order"] == "Asc"
     assert seen["kwargs"]["restrict_to_permanent_storage_hwm_date"] is True
+    assert "sort_order" not in seen["kwargs"]
 
 
 def test_run_export_missing_reference_and_package(monkeypatch, tmp_path) -> None:

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -259,6 +259,31 @@ def test_list_invoices_rejects_page_size_above_openapi_max(monkeypatch) -> None:
     assert "10 and 250" in (exc.value.hint or "")
 
 
+def test_list_invoices_rejects_negative_page_offset(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call client")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        adapters.list_invoices(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            subject_type="Subject1",
+            date_type="Issue",
+            page_size=10,
+            page_offset=-1,
+            sort_order="Desc",
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "0 or greater" in (exc.value.hint or "")
+
+
 def test_list_invoices_rejects_invalid_subject_type(monkeypatch) -> None:
     monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
     monkeypatch.setattr(
@@ -1446,6 +1471,23 @@ def test_list_invoices_without_subject_type_aggregates_lowest_hwm_date(monkeypat
 
     assert result["count"] == 4
     assert result["permanent_storage_hwm_date"] == "2026-01-15T00:00:00Z"
+
+
+def test_merge_permanent_storage_hwm_date_prefers_valid_iso_candidate() -> None:
+    assert (
+        adapters._merge_permanent_storage_hwm_date(
+            "1000-not-date",
+            "2026-01-15T00:00:00Z",
+        )
+        == "2026-01-15T00:00:00Z"
+    )
+    assert (
+        adapters._merge_permanent_storage_hwm_date(
+            "2026-01-15T00:00:00Z",
+            "1000-not-date",
+        )
+        == "2026-01-15T00:00:00Z"
+    )
 
 
 def test_invoice_sort_value_handles_empty_invalid_and_naive_datetime() -> None:

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1340,7 +1340,6 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
             ],
             "hasMore": False,
         },
-        ("Subject1", 2): {"invoices": []},
         ("Subject2", 0): {
             "invoices": [{"ksefNumber": "KSEF-3", "issueDate": "2026-01-04T00:00:00Z"}],
             "isTruncated": True,
@@ -1376,21 +1375,21 @@ def test_list_invoices_without_subject_type_queries_all_subject_types(monkeypatc
         date_to="2026-01-31",
         subject_type=None,
         date_type="Issue",
-        page_size=2,
-        page_offset=1,
+        page_size=10,
+        page_offset=0,
         sort_order="Desc",
     )
 
     assert seen_calls == [
-        ("Subject1", 0, 2),
-        ("Subject2", 0, 2),
-        ("Subject3", 0, 2),
-        ("SubjectAuthorized", 0, 2),
+        ("Subject1", 0, 10),
+        ("Subject2", 0, 10),
+        ("Subject3", 0, 10),
+        ("SubjectAuthorized", 0, 10),
     ]
-    assert result["count"] == 2
-    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-2", "KSEF-DUP"]
+    assert result["count"] == 4
+    assert [item["ksefNumber"] for item in result["items"]] == ["KSEF-3", "KSEF-2", "KSEF-DUP", "KSEF-1"]
     assert result["continuation_token"] == ""
-    assert result["has_more"] is True
+    assert result["has_more"] is False
     assert result["is_truncated"] is True
     assert result["permanent_storage_hwm_date"] == "2026-01-31T23:59:59Z"
 

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1490,6 +1490,16 @@ def test_merge_permanent_storage_hwm_date_prefers_valid_iso_candidate() -> None:
     )
 
 
+def test_merge_permanent_storage_hwm_date_keeps_current_when_both_invalid() -> None:
+    assert (
+        adapters._merge_permanent_storage_hwm_date(
+            "not-a-date-current",
+            "1000-not-date-candidate",
+        )
+        == "not-a-date-current"
+    )
+
+
 def test_invoice_sort_value_handles_empty_invalid_and_naive_datetime() -> None:
     assert adapters._normalize_invoice_sort_value(None) == ""
     assert adapters._normalize_invoice_sort_value("   ") == ""


### PR DESCRIPTION
## Summary
- remove no-op `--sort-order` from `ksef export run` and update tests/docs
- fix `has_more` semantics for multi-subject invoice aggregation after deduplication
- deterministically merge `permanent_storage_hwm_date` across subject streams
- add regression tests for duplicate-only next page and HWM merge behavior

## Validation
- python -m ruff check src tests
- mypy src
- pytest -q -p no:tmpdir tests/cli/unit/test_auth_manager.py -k "not xades"
- pytest -q -p no:tmpdir tests/cli/unit/test_sdk_adapters.py -k "list_invoices_without_subject_type_queries_all_subject_types or list_invoices_without_subject_type_aggregates_lowest_hwm_date or query_all_invoice_subject_types_handles_no_more_after_duplicate_only_next_page or export_run_cli_passes_incremental_options"

## Note
- full `pytest` is blocked in this environment by Windows temp-directory ACL (`PermissionError` on `%TEMP%/pytest-of-smekc`).
