### PR TITLE
feat(cli): add resumable online and batch sessions

### DIFF
--- a/.github/workflows/python-e2e.yml
+++ b/.github/workflows/python-e2e.yml
@@ -22,7 +22,7 @@ jobs:
     name: E2E TEST (token)
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 50
 
     steps:
       - uses: actions/checkout@v5
@@ -86,6 +86,9 @@ jobs:
         run: |
           python -m pytest -q --maxfail=1 --disable-warnings \
             tests/test_e2e_token_flows.py::test_e2e_test_environment_full_flow_token
+          python -m pytest -q --maxfail=1 --disable-warnings \
+            tests/test_e2e_resume_flows.py::test_e2e_test_environment_online_resume_token \
+            tests/test_e2e_resume_flows.py::test_e2e_test_environment_batch_resume_token
 
   e2e-test-xades:
     name: E2E TEST (xades)
@@ -182,7 +185,7 @@ jobs:
     name: E2E DEMO (token)
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 50
 
     steps:
       - uses: actions/checkout@v5
@@ -246,6 +249,9 @@ jobs:
         run: |
           python -m pytest -q --maxfail=1 --disable-warnings \
             tests/test_e2e_token_flows.py::test_e2e_demo_environment_full_flow_token
+          python -m pytest -q --maxfail=1 --disable-warnings \
+            tests/test_e2e_resume_flows.py::test_e2e_demo_environment_online_resume_token \
+            tests/test_e2e_resume_flows.py::test_e2e_demo_environment_batch_resume_token
 
   e2e-demo-xades:
     name: E2E DEMO (xades)

--- a/.github/workflows/python-e2e.yml
+++ b/.github/workflows/python-e2e.yml
@@ -84,12 +84,24 @@ jobs:
           KSEF_TEST_CONTEXT_TYPE: ${{ secrets.KSEF_TEST_CONTEXT_TYPE }}
           KSEF_TEST_CONTEXT_VALUE: ${{ secrets.KSEF_TEST_CONTEXT_VALUE }}
           KSEF_TEST_SUBJECT_TYPE: Subject1
+          KSEF_E2E_RATE_LIMIT_RETRIES: "5"
+          KSEF_E2E_INVOICE_MAX_ATTEMPTS: "120"
+          KSEF_E2E_UPO_MAX_ATTEMPTS: "90"
+          KSEF_E2E_SESSION_MAX_ATTEMPTS: "120"
         run: |
-          python -m pytest -q --maxfail=1 --disable-warnings \
-            tests/test_e2e_token_flows.py::test_e2e_test_environment_full_flow_token
-          python -m pytest -q --maxfail=1 --disable-warnings \
-            tests/test_e2e_resume_flows.py::test_e2e_test_environment_online_resume_token \
-            tests/test_e2e_resume_flows.py::test_e2e_test_environment_batch_resume_token
+          for attempt in 1 2; do
+            if python -m pytest -q --maxfail=1 --disable-warnings \
+              tests/test_e2e_token_flows.py::test_e2e_test_environment_full_flow_token \
+              tests/test_e2e_resume_flows.py::test_e2e_test_environment_online_resume_token \
+              tests/test_e2e_resume_flows.py::test_e2e_test_environment_batch_resume_token; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 2 ]; then
+              exit 1
+            fi
+            echo "TEST token E2E failed on attempt ${attempt}; retrying after cooldown..."
+            sleep 20
+          done
 
   e2e-test-xades:
     name: E2E TEST (xades)
@@ -178,9 +190,19 @@ jobs:
           KSEF_TEST_XADES_PRIVATE_KEY_PEM_B64: ${{ secrets.KSEF_TEST_XADES_PRIVATE_KEY_PEM_B64 }}
           KSEF_TEST_XADES_PRIVATE_KEY_PASSWORD: ${{ secrets.KSEF_TEST_XADES_PRIVATE_KEY_PASSWORD }}
           KSEF_TEST_XADES_SUBJECT_IDENTIFIER_TYPE: certificateSubject
+          KSEF_E2E_RATE_LIMIT_RETRIES: "5"
         run: |
-          python -m pytest -q --maxfail=1 --disable-warnings \
-            tests/test_e2e_token_flows.py::test_e2e_test_environment_full_flow_xades
+          for attempt in 1 2; do
+            if python -m pytest -q --maxfail=1 --disable-warnings \
+              tests/test_e2e_token_flows.py::test_e2e_test_environment_full_flow_xades; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 2 ]; then
+              exit 1
+            fi
+            echo "TEST xades E2E failed on attempt ${attempt}; retrying after cooldown..."
+            sleep 20
+          done
 
   e2e-demo-token:
     name: E2E DEMO (token)

--- a/.github/workflows/python-e2e.yml
+++ b/.github/workflows/python-e2e.yml
@@ -2,6 +2,7 @@ name: Python E2E
 
 on:
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   schedule:

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -48,6 +48,14 @@ Token może zostać przekazany na dwa sposoby:
 
 Wariant per-call jest preferowany w przypadku obsługi wielu kontekstów.
 
+Ważne dla resume workflow:
+- handle sesji (`OnlineSessionHandle`, `BatchSessionHandle`) i metody `client.sessions.*`
+  akceptują `access_token=None`,
+- dzięki temu po wznowieniu z `OnlineSessionState` / `BatchSessionState` możesz polegać na tokenie
+  ustawionym w konstruktorze klienta, bez przekazywania go do każdego wywołania.
+
+Stan sesji serializowany przez SDK nie zawiera tokenów. To świadoma decyzja bezpieczeństwa.
+
 Ważne: payloady requestów w SDK są typed-only. Do metod klientów przekazuj modele z
 `ksef_client.models`, a nie surowe `dict`.
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -30,6 +30,9 @@ sa renderowane z bogatszymi hintami, jesli KSeF zwroci `application/problem+json
 - faktury i UPO:
   - `invoice list`, `invoice download`
   - `send online`, `send batch`, `send status`
+  - `session list/show/status/export/import/drop`
+  - `session online open/send/close`
+  - `session batch open/upload/close`
   - `upo get`, `upo wait`
 - eksport:
   - `export run`, `export status`
@@ -64,7 +67,17 @@ ksef profile show
 ```bash
 ksef invoice list --from 2026-01-01 --to 2026-01-31
 ksef send online --invoice ./fa.xml --wait-upo --save-upo ./out/upo-online.xml
+ksef send online --invoice ./fa.xml --save-session online-demo
+ksef session show --id online-demo
 ksef invoice download --ksef-number <KSEF_NUMBER> --out ./out/
+```
+
+5. Manualny flow resumable:
+
+```bash
+ksef session online open --id online-demo
+ksef session online send --id online-demo --invoice ./fa.xml --wait-status
+ksef session online close --id online-demo
 ```
 
 ## Troubleshooting
@@ -108,6 +121,21 @@ ksef
     online
     batch
     status
+  session
+    list
+    show
+    status
+    export
+    import
+    drop
+    online
+      open
+      send
+      close
+    batch
+      open
+      upload
+      close
   upo
     get
     wait
@@ -139,6 +167,7 @@ Zachowanie profilu:
 
 Brak aktywnego profilu:
 - komendy `auth`, `health`, `invoice`, `send`, `upo`, `export` wymagaja aktywnego profilu,
+- komendy `session ...` rowniez wymagaja aktywnego profilu,
 - komendy `lighthouse ...` dzialaja bez profilu (publiczne API Latarni),
 - jesli profil nie jest ustawiony, CLI zwraca czytelny blad z podpowiedzia:
   - `ksef init --set-active`
@@ -417,6 +446,7 @@ Options:
   --poll-interval FLOAT     [default: 2.0]
   --max-attempts INTEGER    [default: 60]
   --save-upo TEXT
+  --save-session TEXT
   --save-upo-overwrite
   --base-url TEXT
 ```
@@ -424,6 +454,9 @@ Options:
 Uwagi:
 - `--save-upo` wymaga `--wait-upo`.
 - `--save-upo` bez rozszerzenia jest traktowane jako sciezka pliku.
+- `--save-session <id>` zapisuje lokalny checkpoint resumable sesji pod wskazanym identyfikatorem.
+- Przy udanym zakonczeniu komenda nadal zamyka sesje; checkpoint sluzy glownie do inspekcji
+  oraz odzyskania flow po przerwaniu lub bledzie po zapisaniu checkpointu.
 - `--save-upo-overwrite` pozwala nadpisac istniejacy plik UPO wskazany przez `--save-upo`.
 - Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`; CLI normalizuje historyczne `RR` do `FA_RR`.
 
@@ -445,14 +478,233 @@ Options:
   --poll-interval FLOAT     [default: 2.0]
   --max-attempts INTEGER    [default: 120]
   --save-upo TEXT
+  --save-session TEXT
   --save-upo-overwrite
   --base-url TEXT
 ```
 
 Walidacja:
 - dokladnie jedno z `--zip` albo `--dir`.
+- `--save-session <id>` zapisuje lokalny checkpoint resumable sesji pod wskazanym identyfikatorem.
+- Przy udanym zakonczeniu komenda nadal zamyka sesje; checkpoint sluzy glownie do inspekcji
+  oraz odzyskania flow po przerwaniu lub bledzie po zapisaniu checkpointu.
 - `--save-upo-overwrite` pozwala nadpisac istniejacy plik UPO wskazany przez `--save-upo`.
 - Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`; CLI normalizuje historyczne `RR` do `FA_RR`.
+
+## Resumable sessions
+
+CLI utrzymuje osobny checkpoint workflow dla wznowien po restarcie procesu. To cos wiecej niz
+lekki `OnlineSessionState` / `BatchSessionState` z SDK:
+- checkpoint online przechowuje `id`, `profile`, `base_url`, `stage`, `session_state`,
+  `last_invoice_ref`, `sent_invoice_refs`,
+- checkpoint batch przechowuje `id`, `profile`, `base_url`, `stage`, `session_state`,
+  `payload_source`, `uploaded_ordinals`, `last_upo_ref`.
+
+Wazne granice odpowiedzialnosci:
+- checkpoint nie przechowuje tokenow,
+- checkpoint batch nie embeduje ZIP-a ani XML-i,
+- resume batch wymaga zachowania tego samego ZIP-a albo tego samego katalogu zrodlowego.
+
+Przy wygaslym tokenie najpierw odswiez sesje:
+
+```bash
+ksef auth refresh
+```
+
+albo zaloguj sie ponownie, a dopiero potem wykonaj `ksef session ...`.
+
+## `ksef session list`
+
+```text
+Usage: ksef session list
+```
+
+Zwraca checkpointy zapisane dla aktywnego profilu.
+
+## `ksef session show`
+
+```text
+Usage: ksef session show --id TEXT
+```
+
+Pokazuje skrot i pelny JSON checkpointu.
+
+## `ksef session status`
+
+```text
+Usage: ksef session status [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --invoice-ref TEXT
+```
+
+Uwagi:
+- bez `--invoice-ref` CLI pobiera status sesji,
+- z `--invoice-ref` CLI pobiera status konkretnej faktury w sesji online.
+
+## `ksef session export`
+
+```text
+Usage: ksef session export [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --out TEXT                [required]
+```
+
+Eksportuje checkpoint do wskazanego pliku JSON albo katalogu.
+
+## `ksef session import`
+
+```text
+Usage: ksef session import [OPTIONS]
+
+Options:
+  --in TEXT                 [required]
+  --id TEXT
+```
+
+Uwagi:
+- importowany checkpoint musi nalezec do wybranego profilu,
+- `--id` pozwala nadpisac identyfikator podczas importu.
+
+## `ksef session drop`
+
+```text
+Usage: ksef session drop --id TEXT
+```
+
+Usuwa lokalny checkpoint. Nie wykonuje zadnych operacji na sesji po stronie KSeF.
+
+## `ksef session online open`
+
+```text
+Usage: ksef session online open [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --system-code TEXT        [default: FA (3)]
+  --schema-version TEXT     [default: 1-0E]
+  --form-value TEXT         [default: FA]
+  --upo-v43
+  --base-url TEXT
+```
+
+Otwiera sesje online i zapisuje checkpoint w stanie `opened`.
+
+## `ksef session online send`
+
+```text
+Usage: ksef session online send [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --invoice TEXT            [required]
+  --wait-status
+  --wait-upo
+  --poll-interval FLOAT     [default: 2.0]
+  --max-attempts INTEGER    [default: 60]
+  --save-upo TEXT
+  --save-upo-overwrite
+```
+
+Uwagi:
+- komenda wznawia sesje z checkpointu i wysyla kolejna fakture,
+- po sukcesie aktualizuje `last_invoice_ref` i `sent_invoice_refs`,
+- `--save-upo` wymaga `--wait-upo`.
+
+## `ksef session online close`
+
+```text
+Usage: ksef session online close --id TEXT
+```
+
+Zamyka sesje online i aktualizuje checkpoint do stanu `closed`.
+
+## `ksef session batch open`
+
+```text
+Usage: ksef session batch open [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --zip TEXT
+  --dir TEXT
+  --system-code TEXT        [default: FA (3)]
+  --schema-version TEXT     [default: 1-0E]
+  --form-value TEXT         [default: FA]
+  --upo-v43
+  --base-url TEXT
+```
+
+Walidacja:
+- dokladnie jedno z `--zip` albo `--dir`.
+
+Komenda otwiera sesje batch i zapisuje checkpoint z deskryptorem `payload_source`.
+
+## `ksef session batch upload`
+
+```text
+Usage: ksef session batch upload [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --parallelism INTEGER     [default: 4]
+```
+
+Uwagi:
+- CLI odtwarza ZIP z `payload_source`,
+- weryfikuje, czy hash i rozmiar zrodla nie zmienily sie od czasu utworzenia checkpointu,
+- wznawia upload tylko brakujacych partow, pomijajac `uploaded_ordinals`.
+
+## `ksef session batch close`
+
+```text
+Usage: ksef session batch close [OPTIONS]
+
+Options:
+  --id TEXT                 [required]
+  --wait-status
+  --wait-upo
+  --poll-interval FLOAT     [default: 2.0]
+  --max-attempts INTEGER    [default: 120]
+  --save-upo TEXT
+  --save-upo-overwrite
+```
+
+Uwagi:
+- komenda zamyka sesje batch bez potrzeby ponownego ladowania ZIP-a,
+- `--wait-status` i `--wait-upo` dzialaja analogicznie do `send batch`,
+- po odczycie statusu CLI zapisuje `last_upo_ref` w checkpointcie.
+
+## Przyklady resume flow
+
+Manualny online:
+
+```bash
+ksef session online open --id online-demo
+ksef session online send --id online-demo --invoice ./fa.xml --wait-status
+ksef session online close --id online-demo
+```
+
+Manualny batch:
+
+```bash
+ksef session batch open --id batch-demo --zip ./batch.zip
+ksef session batch upload --id batch-demo --parallelism 4
+ksef session batch close --id batch-demo --wait-status --wait-upo
+```
+
+One-shot z checkpointem i recovery po przerwaniu:
+
+```bash
+ksef send batch --zip ./batch.zip --save-session batch-demo
+# jesli proces zostal przerwany po zapisaniu checkpointu:
+ksef session show --id batch-demo
+ksef session batch upload --id batch-demo --parallelism 4
+ksef session batch close --id batch-demo --wait-status --wait-upo
+```
 
 ## `ksef upo get`
 
@@ -571,11 +823,19 @@ Lokalizacja token fallback:
 - Cache metadanych:
   - Windows: `%LOCALAPPDATA%/ksef-cli/cache.json`
   - Linux/macOS: `~/.cache/ksef-cli/cache.json`
+- Checkpointy resumable sesji:
+  - Windows: `%LOCALAPPDATA%/ksef-cli/sessions/<profile>/<id>.json`
+  - Linux/macOS: `~/.cache/ksef-cli/sessions/<profile>/<id>.json`
 - Fallback token store:
   - Windows: `%LOCALAPPDATA%/ksef-cli/tokens.json`
   - Linux/macOS: `~/.cache/ksef-cli/tokens.json`
 - Kopia uszkodzonego configu:
   - `config.corrupt-<timestamp>.json` w tym samym katalogu co `config.json`.
+
+Uwagi:
+- checkpointy sesji sa zapisywane atomowo,
+- poza Windows CLI probuje wymusic uprawnienia `0600`,
+- checkpointy nie zawieraja tokenow ani tresci faktur.
 
 ## JSON contract (`--json`)
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,7 +4,9 @@ Katalog zawiera minimalne skrypty uruchomieniowe prezentujące podstawowe scenar
 - autoryzacja tokenem KSeF (uzyskanie `accessToken` i `refreshToken`),
 - autoryzacja podpisem XAdES (certyfikat + klucz prywatny albo kontener PKCS#12),
 - wyszukiwanie metadanych faktur,
-- wysyłka faktury w sesji online (XML FA(3) z pliku).
+- wysyłka faktury w sesji online (XML FA(3) z pliku),
+- resume sesji online z `OnlineSessionState`,
+- resume sesji batch z `BatchSessionState`.
 
 Polecenia w tym dokumencie zakładają uruchomienie z katalogu `ksef-client-python`.
 
@@ -82,6 +84,7 @@ python docs/examples/invoice_list.py
 ### `invoice_send.py`
 
 Wysyła fakturę w sesji online. Skrypt zakłada dostępność poprawnego pliku XML faktury w wersji FA(3).
+Pokazuje aktualne API handle'a sesji: `open_session() -> session.send_invoice() -> session.close()`.
 
 Dodatkowe zmienne:
 
@@ -91,4 +94,34 @@ Uruchomienie:
 
 ```bash
 python docs/examples/invoice_send.py
+```
+
+### `session_resume_online.py`
+
+Otwiera sesję online, serializuje lekki JSON stanu, a następnie wznawia sesję w nowym kliencie.
+
+Dodatkowe zmienne:
+
+- `KSEF_INVOICE_XML_PATH` – ścieżka do pliku XML (FA(3))
+- `KSEF_SESSION_STATE_PATH` – opcjonalna ścieżka do pliku JSON ze stanem sesji
+
+Uruchomienie:
+
+```bash
+python docs/examples/session_resume_online.py
+```
+
+### `session_resume_batch.py`
+
+Otwiera sesję batch, serializuje lekki JSON stanu, a następnie wznawia sesję z tego samego ZIP-a.
+
+Dodatkowe zmienne:
+
+- `KSEF_BATCH_ZIP_PATH` – ścieżka do ZIP-a z fakturami XML
+- `KSEF_BATCH_STATE_PATH` – opcjonalna ścieżka do pliku JSON ze stanem sesji
+
+Uruchomienie:
+
+```bash
+python docs/examples/session_resume_batch.py
 ```

--- a/docs/examples/session_resume_batch.py
+++ b/docs/examples/session_resume_batch.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import os
-import time
 from pathlib import Path
 
 from ksef_client import KsefClient, KsefClientOptions, KsefEnvironment
 from ksef_client import models as m
-from ksef_client.services import AuthCoordinator, OnlineSessionWorkflow
+from ksef_client.services import AuthCoordinator, BatchSessionState, BatchSessionWorkflow
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -21,9 +20,10 @@ def main() -> None:
     token = _env("KSEF_TOKEN")
     context_type = _env("KSEF_CONTEXT_TYPE")
     context_value = _env("KSEF_CONTEXT_VALUE")
-    invoice_xml_path = _env("KSEF_INVOICE_XML_PATH")
+    zip_path = Path(_env("KSEF_BATCH_ZIP_PATH"))
+    state_path = Path(os.getenv("KSEF_BATCH_STATE_PATH", "batch-session-state.json"))
 
-    invoice_xml = Path(invoice_xml_path).read_bytes()
+    zip_bytes = zip_path.read_bytes()
 
     with KsefClient(KsefClientOptions(base_url=base_url)) as client:
         token_cert_pem = client.security.get_public_key_certificate_pem(
@@ -41,29 +41,27 @@ def main() -> None:
             poll_interval_seconds=2.0,
         ).access_token
 
-        workflow = OnlineSessionWorkflow(client.sessions)
+        workflow = BatchSessionWorkflow(client.sessions, client.http_client)
         session = workflow.open_session(
             form_code=m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA"),
+            zip_bytes=zip_bytes,
             public_certificate=symmetric_cert_pem,
             access_token=access_token,
         )
-        send_result = session.send_invoice(invoice_xml, access_token=access_token)
-        invoice_reference = send_result.reference_number
+        state_path.write_text(session.get_state().to_json(), encoding="ascii")
 
-        status = None
-        for _ in range(60):
-            status = session.get_invoice_status(invoice_reference, access_token=access_token)
-            code = int(status.status.code)
-            if code == 200:
-                break
-            if code not in {100, 150}:
-                raise RuntimeError(status.to_dict())
-            time.sleep(2)
+    resumed_state = BatchSessionState.from_json(state_path.read_text(encoding="ascii"))
 
-        session.close(access_token=access_token)
+    with KsefClient(KsefClientOptions(base_url=base_url), access_token=access_token) as client:
+        resumed = BatchSessionWorkflow(client.sessions, client.http_client).resume_session(
+            resumed_state,
+            zip_bytes=zip_bytes,
+        )
+        resumed.upload_parts(parallelism=4)
+        resumed.close()
 
-    print(f"Invoice reference: {invoice_reference}")
-    print(f"KSeF number: {None if status is None else status.ksef_number}")
+    print(f"Saved state to: {state_path}")
+    print(f"Session reference: {resumed_state.reference_number}")
 
 
 if __name__ == "__main__":

--- a/docs/examples/session_resume_online.py
+++ b/docs/examples/session_resume_online.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ksef_client import KsefClient, KsefClientOptions, KsefEnvironment
 from ksef_client import models as m
-from ksef_client.services import AuthCoordinator, OnlineSessionWorkflow
+from ksef_client.services import AuthCoordinator, OnlineSessionState, OnlineSessionWorkflow
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -22,6 +22,7 @@ def main() -> None:
     context_type = _env("KSEF_CONTEXT_TYPE")
     context_value = _env("KSEF_CONTEXT_VALUE")
     invoice_xml_path = _env("KSEF_INVOICE_XML_PATH")
+    state_path = Path(os.getenv("KSEF_SESSION_STATE_PATH", "online-session-state.json"))
 
     invoice_xml = Path(invoice_xml_path).read_bytes()
 
@@ -47,12 +48,18 @@ def main() -> None:
             public_certificate=symmetric_cert_pem,
             access_token=access_token,
         )
-        send_result = session.send_invoice(invoice_xml, access_token=access_token)
+        state_path.write_text(session.get_state().to_json(), encoding="ascii")
+
+    resumed_state = OnlineSessionState.from_json(state_path.read_text(encoding="ascii"))
+
+    with KsefClient(KsefClientOptions(base_url=base_url), access_token=access_token) as client:
+        resumed = OnlineSessionWorkflow(client.sessions).resume_session(resumed_state)
+        send_result = resumed.send_invoice(invoice_xml)
         invoice_reference = send_result.reference_number
 
         status = None
         for _ in range(60):
-            status = session.get_invoice_status(invoice_reference, access_token=access_token)
+            status = resumed.get_invoice_status(invoice_reference)
             code = int(status.status.code)
             if code == 200:
                 break
@@ -60,8 +67,9 @@ def main() -> None:
                 raise RuntimeError(status.to_dict())
             time.sleep(2)
 
-        session.close(access_token=access_token)
+        resumed.close()
 
+    print(f"Saved state to: {state_path}")
     print(f"Invoice reference: {invoice_reference}")
     print(f"KSeF number: {None if status is None else status.ksef_number}")
 

--- a/docs/services/workflows.md
+++ b/docs/services/workflows.md
@@ -1,26 +1,31 @@
 # Workflows i narzędzia pomocnicze (`ksef_client.services.workflows`)
 
-Klasy łączące wywołania API z operacjami lokalnymi (kryptografia, ZIP) w spójne scenariusze. W większości integracji stanowią podstawową warstwę użycia biblioteki.
+Klasy łączące wywołania API z operacjami lokalnymi: kryptografia, ZIP, upload partów i polling.
+W większości integracji stanowią podstawową warstwę użycia biblioteki.
 
 ## Klasy pomocnicze do wysyłki i pobierania partów
 
-### `BatchUploadHelper.upload_parts(part_upload_requests, parts, parallelism=1)`
+### `BatchUploadHelper.upload_parts(part_upload_requests, parts, parallelism=1, skip_ordinals=None, progress_callback=None)`
 
 Wysyła party paczki wsadowej na pre-signed URL zwrócone w `partUploadRequests`.
 
 Zasady wynikające z KSeF:
-- nagłówek `Authorization` nie jest przesyłany (wysyłka po pre-signed URL),
-- pary łączone są po `ordinalNumber` (dlatego `parts` może zostać przekazane jako `list[bytes]` albo `list[tuple[int, bytes]]`).
+- nagłówek `Authorization` nie jest przesyłany,
+- pary łączone są po `ordinalNumber`, dlatego `parts` może być przekazane jako `list[bytes]`
+  albo `list[tuple[int, bytes]]`.
 
-`parallelism` wykorzystuje `ThreadPoolExecutor` (sync). Dla większych paczek zwykle skraca czas wysyłki.
+Parametry:
+- `parallelism`: wykorzystuje `ThreadPoolExecutor` w wariancie sync,
+- `skip_ordinals`: pomija wskazane numery partów,
+- `progress_callback(ordinal_number)`: wywoływany po każdym udanym uploadzie partu.
 
-### `AsyncBatchUploadHelper.upload_parts(part_upload_requests, parts)`
+### `AsyncBatchUploadHelper.upload_parts(part_upload_requests, parts, skip_ordinals=None, progress_callback=None)`
 
-Wariant asynchroniczny – wysyła party równolegle przez `asyncio.gather()`.
+Wariant asynchroniczny. Również obsługuje `skip_ordinals` i `progress_callback`.
 
 ### `ExportDownloadHelper.download_parts(parts)` / `download_parts_with_hash(parts)`
 
-Pobiera części paczki eksportu (pre-signed URL). Token nie jest wymagany.
+Pobiera części paczki eksportu z pre-signed URL. Token nie jest wymagany.
 
 `download_parts_with_hash()` zwraca `(bytes, x-ms-meta-hash)` dla każdej części.
 
@@ -30,103 +35,163 @@ Async odpowiednik: `AsyncExportDownloadHelper`.
 
 ### `AuthCoordinator.authenticate_with_xades_key_pair(...) -> AuthResult`
 
-Wariant uwierzytelnienia XAdES oparty o `XadesKeyPair`. Zamiast przekazywania surowych stringów PEM, wykorzystywany jest obiekt wczytany z kontenera PKCS#12 (`.pfx`/`.p12`) albo z pary plików certyfikat/klucz.
-
-Powiązane: `XadesKeyPair` (opis: `services/xades.md`).
+Wariant uwierzytelnienia XAdES oparty o `XadesKeyPair`.
 
 ### `AuthCoordinator.authenticate_with_xades(...) -> AuthResult`
 
 Scenariusz:
-1) `POST /auth/challenge`
-2) budowa XML `AuthTokenRequest`
-3) podpis XAdES (wymaga dodatku `xml`)
-4) `POST /auth/xades-signature`
-5) polling `GET /auth/{referenceNumber}` aż `status.code == 200`
-6) `POST /auth/token/redeem` → `accessToken` + `refreshToken`
-
-Najczęściej używane parametry:
-- `context_identifier_type`: `"nip" | "internalId" | "nipVatUe" | "peppolId"`
-- `context_identifier_value`: np. NIP
-- `subject_identifier_type`: np. `"certificateSubject"` (lub `"certificateFingerprint"`)
-- `verify_certificate_chain`: przydatne w TE
-- `enforce_xades_compliance`: gdy `True`, ustawia nagłówek `X-KSeF-Feature: enforce-xades-compliance`
-- `poll_interval_seconds`, `max_attempts`: parametry pollingu
+1. `POST /auth/challenge`
+2. budowa XML `AuthTokenRequest`
+3. podpis XAdES
+4. `POST /auth/xades-signature`
+5. polling `GET /auth/{referenceNumber}` aż `status.code == 200`
+6. `POST /auth/token/redeem`
 
 ### `AuthCoordinator.authenticate_with_ksef_token(...) -> AuthResult`
 
-Scenariusz analogiczny, ale zamiast XAdES:
-- szyfrowanie wartości `token|timestampMs` certyfikatem KSeF (`KsefTokenEncryption`)
-- wysłanie JSON na `POST /auth/ksef-token`
-
-Parametry:
-- `method`: `"rsa"` (domyślnie) albo `"ec"`
-- `ec_output_format`: `"java"` lub `"csharp"` – ważne tylko dla `ec` (format bajtów zgodny z ekosystemem)
+Scenariusz analogiczny, ale z szyfrowaniem wartości `token|timestampMs` certyfikatem KSeF
+(`KsefTokenEncryption`) i wysyłką na `POST /auth/ksef-token`.
 
 Async odpowiednik: `AsyncAuthCoordinator`.
 
 ### `AuthResult`
 
-- `reference_number`: numer operacji uwierzytelnienia
-- `authentication_token`: token tymczasowy (do statusu + redeem)
-- `tokens`: `AuthenticationTokensResponse` (`access_token`, `refresh_token`)
+- `reference_number`
+- `authentication_token`
+- `tokens` / wygodne aliasy `access_token`, `refresh_token`
 
 ## Sesja interaktywna (online)
 
-### `OnlineSessionWorkflow.open_session(...) -> OnlineSessionResult`
+### `OnlineSessionWorkflow.open_session(...) -> OnlineSessionHandle`
 
-Buduje `EncryptionData` na bazie certyfikatu KSeF (`SymmetricKeyEncryption`), otwiera sesję i zwraca:
+Buduje `EncryptionData` na bazie certyfikatu KSeF (`SymmetricKeyEncryption`), otwiera sesję
+i zwraca handle sesji.
 
-- `session_reference_number`
-- `encryption_data` (klucz/IV + encryptionInfo)
+### `OnlineSessionWorkflow.resume_session(state, *, access_token=None) -> OnlineSessionHandle`
 
-### `OnlineSessionWorkflow.send_invoice(...)`
+Wznawia sesję z `OnlineSessionState`. Stan nie zawiera tokenu, więc po wznowieniu:
+- przekaż `access_token` jawnie, albo
+- ustaw token na kliencie `KsefClient(..., access_token=...)`.
 
-Szyfruje XML faktury (AES-256-CBC/PKCS7), liczy hashe/rozmiary i wysyła na:
-`POST /sessions/online/{referenceNumber}/invoices`
+### `OnlineSessionHandle`
 
-Parametry:
-- `offline_mode`: flaga trybu offline (jeśli dotyczy)
-- `hash_of_corrected_invoice`: wymagane dla korekty technicznej (jeśli dotyczy)
+Publiczne pola i metody:
+- `reference_number`
+- `session_reference_number` jako alias kompatybilności
+- `valid_until`
+- `form_code`
+- `encryption_data`
+- `get_state() -> OnlineSessionState`
+- `send_invoice(...)`
+- `get_status()`
+- `list_invoices()`
+- `list_failed_invoices()`
+- `get_invoice_status(...)`
+- `get_invoice_upo_by_ref(...)`
+- `get_invoice_upo_by_ksef(...)`
+- `get_upo(...)`
+- `close()`
 
-### `OnlineSessionWorkflow.close_session(reference_number, access_token)`
+### `OnlineSessionState`
 
-Zamyka sesję i inicjuje generowanie UPO.
+Lekki, wersjonowany stan JSON przeznaczony do resume:
+- `schema_version`
+- `kind="online"`
+- `reference_number`
+- `form_code`
+- `valid_until`
+- `symmetric_key_base64`
+- `iv_base64`
+- `upo_v43`
 
-Async odpowiednik: `AsyncOnlineSessionWorkflow`.
+Nie zawiera:
+- tokenów,
+- XML faktur,
+- `invoice_reference`.
 
-### `OnlineSessionResult`
+### Zgodność wsteczna
 
-- `session_reference_number`
-- `encryption_data` (`EncryptionData`)
+`OnlineSessionResult` pozostaje aliasem do `OnlineSessionHandle`.
+
+Async odpowiedniki:
+- `AsyncOnlineSessionWorkflow`
+- `AsyncOnlineSessionHandle`
 
 ## Sesja wsadowa (batch)
 
-### `BatchSessionWorkflow.open_upload_and_close(...) -> str`
+### `BatchSessionWorkflow.open_session(...) -> BatchSessionHandle`
 
 Scenariusz:
-1) budowa `EncryptionData` z `SymmetricKeyEncryption`
-2) ZIP → podział ≤100MB → szyfrowanie partów
-3) `POST /sessions/batch` (open)
-4) wysyłka partów wg `partUploadRequests` (bez Bearer)
-5) `POST /sessions/batch/{referenceNumber}/close`
+1. budowa `EncryptionData` z `SymmetricKeyEncryption`,
+2. ZIP -> podział <=100MB -> szyfrowanie partów,
+3. `POST /sessions/batch` (open),
+4. zwrot handle'a gotowego do uploadu partów.
 
-Parametry:
-- `offline_mode`: flaga trybu offline (jeśli dotyczy)
-- `parallelism`: poziom równoległości wysyłki (sync)
-- `upo_v43`: negocjacja UPO v4-3 nagłówkiem `X-KSeF-Feature`
+### `BatchSessionWorkflow.resume_session(state, *, zip_bytes, access_token=None) -> BatchSessionHandle`
 
-Zwraca `referenceNumber` sesji wsadowej.
+Wznawia sesję z `BatchSessionState` i odtwarza zaszyfrowane party na podstawie przekazanego
+`zip_bytes`.
 
-Async odpowiednik: `AsyncBatchSessionWorkflow`.
+Workflow weryfikuje, że odtworzony `BatchFileInfo` jest identyczny z zapisanym w stanie.
+Jeśli źródło batch się zmieniło, resume kończy się błędem i upload nie jest wykonywany.
+
+### `BatchSessionWorkflow.open_upload_and_close(...) -> str`
+
+One-shot convenience API z zachowaną zgodnością wsteczną:
+`open_session() -> upload_parts() -> close()`.
+
+### `BatchSessionHandle`
+
+Publiczne pola i metody:
+- `reference_number`
+- `session_reference_number` jako alias kompatybilności
+- `form_code`
+- `batch_file`
+- `part_upload_requests`
+- `encryption_data`
+- `get_state() -> BatchSessionState`
+- `upload_parts(parallelism=1, skip_ordinals=None, progress_callback=None)`
+- `get_status()`
+- `list_invoices()`
+- `list_failed_invoices()`
+- `get_upo(...)`
+- `close()`
+
+### `BatchSessionState`
+
+Lekki, wersjonowany stan JSON przeznaczony do resume:
+- `schema_version`
+- `kind="batch"`
+- `reference_number`
+- `form_code`
+- `batch_file`
+- `part_upload_requests`
+- `symmetric_key_base64`
+- `iv_base64`
+- `upo_v43`
+- `offline_mode`
+
+Nie zawiera:
+- tokenów,
+- ZIP-a,
+- XML faktur,
+- listy już wysłanych `uploaded_ordinals`,
+- ścieżki do źródła batch.
+
+Te dane powinny być utrzymywane przez warstwę workflow/CLI po stronie aplikacji.
+
+Async odpowiedniki:
+- `AsyncBatchSessionWorkflow`
+- `AsyncBatchSessionHandle`
 
 ## Eksport (pobieranie paczek)
 
 ### `ExportWorkflow.download_and_process_package(package, encryption_data) -> PackageProcessingResult`
 
-Pobiera wszystkie części paczki (pre-signed URL), odszyfrowuje je AES i skleja w ZIP.
+Pobiera wszystkie części paczki eksportu, odszyfrowuje je AES i skleja w ZIP.
 Potem rozpakowuje ZIP bezpiecznie (`unzip_bytes_safe`) i zwraca:
-- `metadata_summaries` – rekordy z `_metadata.json` (jeśli plik był w paczce)
-- `invoice_xml_files` – mapę `nazwaPliku.xml -> treść XML`
+- `metadata_summaries`
+- `invoice_xml_files`
 
 Async odpowiednik: `AsyncExportWorkflow`.
 

--- a/docs/workflows/batch-session.md
+++ b/docs/workflows/batch-session.md
@@ -1,14 +1,20 @@
 # Workflow: sesja wsadowa (batch)
 
-Scenariusz obejmuje: przygotowanie ZIP z wieloma XML, podział na części ≤100MB, szyfrowanie, otwarcie sesji wsadowej, wysyłkę partów na pre-signed URL oraz zamknięcie sesji.
+Scenariusz obejmuje: przygotowanie ZIP z wieloma XML, podział na części <=100MB, szyfrowanie,
+otwarcie sesji wsadowej, serializację lekkiego stanu JSON, wznowienie po restarcie procesu,
+wysyłkę brakujących partów na pre-signed URL oraz zamknięcie sesji.
 
-Rekomendowane podejście: `BatchSessionWorkflow.open_upload_and_close()`.
+Rekomendowane podejście:
+- `BatchSessionWorkflow.open_session()` do otwarcia sesji,
+- `BatchSessionHandle.upload_parts()` do wysyłki partów,
+- `BatchSessionWorkflow.resume_session()` do wznowienia z `BatchSessionState`,
+- `BatchSessionWorkflow.open_upload_and_close()` jako one-shot convenience API bez resume.
 
-## Przykład (sync)
+## Przykład (sync, z resume)
 
 ```python
 from ksef_client import KsefClient, KsefClientOptions, KsefEnvironment, models as m
-from ksef_client.services import AuthCoordinator, BatchSessionWorkflow
+from ksef_client.services import AuthCoordinator, BatchSessionState, BatchSessionWorkflow
 from ksef_client.utils import build_zip
 
 KSEF_TOKEN = "<TOKEN_KSEF>"
@@ -17,11 +23,14 @@ CONTEXT_VALUE = "5265877635"
 
 FORM_CODE = m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
 
-zip_bytes = build_zip({
-    "invoice1.xml": b\"\"\"<Invoice>...</Invoice>\"\"\",
-    "invoice2.xml": b\"\"\"<Invoice>...</Invoice>\"\"\",
-})
+zip_bytes = build_zip(
+    {
+        "invoice1.xml": b"""<Invoice>...</Invoice>""",
+        "invoice2.xml": b"""<Invoice>...</Invoice>""",
+    }
+)
 
+# Proces 1: auth + open + zapis lekkiego stanu JSON
 with KsefClient(KsefClientOptions(base_url=KsefEnvironment.DEMO.value)) as client:
     token_cert = client.security.get_public_key_certificate_pem(
         m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION,
@@ -40,22 +49,105 @@ with KsefClient(KsefClientOptions(base_url=KsefEnvironment.DEMO.value)) as clien
     ).access_token
 
     workflow = BatchSessionWorkflow(client.sessions, client.http_client)
-    session_ref = workflow.open_upload_and_close(
+    session = workflow.open_session(
         form_code=FORM_CODE,
         zip_bytes=zip_bytes,
         public_certificate=sym_cert,
         access_token=access_token,
         offline_mode=None,
-        parallelism=4,
+        upo_v43=False,
     )
+    state_json = session.get_state().to_json()
 
-print(session_ref)
+# Proces 2: nowy klient + resume z JSON i tym samym ZIP-em
+state = BatchSessionState.from_json(state_json)
+
+with KsefClient(
+    KsefClientOptions(base_url=KsefEnvironment.DEMO.value),
+    access_token=access_token,
+) as client:
+    workflow = BatchSessionWorkflow(client.sessions, client.http_client)
+    session = workflow.resume_session(state, zip_bytes=zip_bytes)
+    session.upload_parts(parallelism=4)
+    session.close()
+
+print(session.reference_number)
 ```
+
+## Kontrakt stanu SDK
+
+`BatchSessionState` serializuje wyłącznie dane potrzebne do wznowienia sesji i odtworzenia uploadu:
+- `schema_version`
+- `kind="batch"`
+- `reference_number`
+- `form_code`
+- `batch_file`
+- `part_upload_requests`
+- `symmetric_key_base64`
+- `iv_base64`
+- `upo_v43`
+- `offline_mode`
+
+Nie są serializowane:
+- `access_token`
+- ZIP wsadowy
+- XML faktur
+- ścieżka do pliku / katalogu źródłowego
+- lista już wysłanych ordinals
+
+To rozróżnienie jest celowe:
+- stan SDK pozostaje lekki i przenośny,
+- pełny checkpoint operacyjny dla batch resume wymaga dodatkowego zapisania źródła payloadu i
+  listy `uploaded_ordinals`; robi to CLI pod `ksef session ...`.
+
+## Publiczne API handle'a
+
+`BatchSessionHandle` udostępnia:
+- `reference_number`
+- `session_reference_number` jako alias kompatybilności
+- `form_code`
+- `batch_file`
+- `part_upload_requests`
+- `encryption_data`
+- `get_state()`
+- `upload_parts()`
+- `get_status()`
+- `list_invoices()`
+- `list_failed_invoices()`
+- `get_upo()`
+- `close()`
+
+## Resume i walidacja źródła batch
+
+`resume_session(state, zip_bytes=...)` odtwarza zaszyfrowane party z podanego ZIP-a i porównuje
+odtworzone `BatchFileInfo` z danymi zapisanymi w `BatchSessionState`.
+
+Jeśli ZIP różni się od oryginału, workflow przerywa działanie błędem i nie próbuje uploadu.
+
+To oznacza, że po restarcie procesu musisz zachować:
+- ten sam ZIP wejściowy, albo
+- ten sam katalog źródłowy, z którego ponownie zbudujesz identyczny ZIP.
+
+## Upload częściowy i checkpointing
+
+`BatchUploadHelper.upload_parts()` oraz `BatchSessionHandle.upload_parts()` obsługują:
+- `skip_ordinals`
+- `progress_callback`
+
+To pozwala budować własny checkpointing wokół SDK, np. zapisywać numer partu po każdym sukcesie
+i po wznowieniu wywołać:
+
+```python
+session.upload_parts(skip_ordinals={1, 2, 3}, parallelism=4)
+```
+
+CLI wykorzystuje dokładnie ten mechanizm i zapisuje `uploaded_ordinals` w lokalnym checkpointcie.
 
 ## Uwagi
 
-- Wysyłka partów odbywa się na pre-signed URL: **bez Bearer tokena** (workflow wykonuje wywołania z `skip_auth=True`).
-- Dla `FA_RR (1)` w wersji `1-1E` przekazuj `formCode.value="FA_RR"` zamiast `RR`.
-- Limit czasu wysyłki w sesji wsadowej wynosi **liczba partów × 20 minut na każdy part**; liczba partów wpływa bezpośrednio na czas dostępny na wysyłkę.
-- Podział ZIP musi nastąpić **przed szyfrowaniem** (biblioteka wykonuje to w `encrypt_batch_parts()`).
-- Korelacja statusów z plikami źródłowymi jest możliwa przez zapisanie hashy SHA-256 faktur (przed szyfrowaniem) i mapowanie ich na identyfikatory w procesie weryfikacji (`invoiceHash`).
+- Wysyłka partów odbywa się na pre-signed URL: bez Bearer tokena.
+- Limit czasu wysyłki w sesji wsadowej wynosi liczba partów x 20 minut na każdy part.
+- Podział ZIP musi nastąpić przed szyfrowaniem; biblioteka wykonuje to w `encrypt_batch_parts()`.
+- Korelacja statusów z plikami źródłowymi jest możliwa przez zapisanie hashy SHA-256 faktur i
+  mapowanie ich na identyfikatory w procesie weryfikacji (`invoiceHash`).
+- `AsyncBatchSessionWorkflow` i `AsyncBatchSessionHandle` oferują lustrzane API asynchroniczne.

--- a/docs/workflows/online-session.md
+++ b/docs/workflows/online-session.md
@@ -1,23 +1,29 @@
 # Workflow: sesja interaktywna (online)
 
-Scenariusz obejmuje: otwarcie sesji, wysyłkę jednej lub wielu faktur, sprawdzanie statusów, zamknięcie sesji oraz pobranie UPO.
+Scenariusz obejmuje: otwarcie sesji, serializację lekkiego stanu JSON, wznowienie po restarcie procesu,
+wysyłkę jednej lub wielu faktur, sprawdzanie statusów, zamknięcie sesji oraz pobranie UPO.
 
-Rekomendowane podejście: `OnlineSessionWorkflow` oraz metody `client.sessions.*` do sprawdzania statusów.
+Rekomendowane podejście:
+- `OnlineSessionWorkflow.open_session()` do otwarcia sesji,
+- `OnlineSessionHandle` do dalszych operacji na sesji,
+- `OnlineSessionWorkflow.resume_session()` do wznowienia z `OnlineSessionState`.
 
-## Przykład (sync)
+## Przykład (sync, z resume)
 
 ```python
 import time
+
 from ksef_client import KsefClient, KsefClientOptions, KsefEnvironment, models as m
-from ksef_client.services import AuthCoordinator, OnlineSessionWorkflow
+from ksef_client.services import AuthCoordinator, OnlineSessionState, OnlineSessionWorkflow
 
 KSEF_TOKEN = "<TOKEN_KSEF>"
 CONTEXT_TYPE = "nip"
 CONTEXT_VALUE = "5265877635"
-INVOICE_XML = b\"\"\"<Invoice>...</Invoice>\"\"\"  # bytes
+INVOICE_XML = b"""<Invoice>...</Invoice>"""
 
 FORM_CODE = m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
 
+# Proces 1: auth + open + zapis lekkiego stanu JSON
 with KsefClient(KsefClientOptions(base_url=KsefEnvironment.DEMO.value)) as client:
     token_cert = client.security.get_public_key_certificate_pem(
         m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION,
@@ -42,23 +48,23 @@ with KsefClient(KsefClientOptions(base_url=KsefEnvironment.DEMO.value)) as clien
         access_token=access_token,
         upo_v43=False,
     )
+    state_json = session.get_state().to_json()
 
-    send = workflow.send_invoice(
-        session_reference_number=session.session_reference_number,
-        invoice_xml=INVOICE_XML,
-        encryption_data=session.encryption_data,
-        access_token=access_token,
-        offline_mode=None,
-        hash_of_corrected_invoice=None,
-    )
+# Proces 2: nowy klient + resume z JSON
+state = OnlineSessionState.from_json(state_json)
+
+with KsefClient(
+    KsefClientOptions(base_url=KsefEnvironment.DEMO.value),
+    access_token=access_token,
+) as client:
+    workflow = OnlineSessionWorkflow(client.sessions)
+    session = workflow.resume_session(state)
+
+    send = session.send_invoice(INVOICE_XML)
     invoice_reference = send.reference_number
 
     for _ in range(60):
-        status = client.sessions.get_session_invoice_status(
-            session.session_reference_number,
-            invoice_reference,
-            access_token=access_token,
-        )
+        status = session.get_invoice_status(invoice_reference)
         code = int(status.status.code)
         if code == 200:
             break
@@ -66,17 +72,63 @@ with KsefClient(KsefClientOptions(base_url=KsefEnvironment.DEMO.value)) as clien
             raise RuntimeError(status.to_dict())
         time.sleep(2)
 
-    workflow.close_session(session.session_reference_number, access_token)
+    session.close()
 
 print("OK")
 ```
 
+## Kontrakt stanu SDK
+
+`OnlineSessionState` serializuje wyłącznie dane potrzebne do wznowienia sesji:
+- `schema_version`
+- `kind="online"`
+- `reference_number`
+- `form_code`
+- `valid_until`
+- `symmetric_key_base64`
+- `iv_base64`
+- `upo_v43`
+
+Nie są serializowane:
+- `access_token`
+- XML faktur
+- wynik wysyłki / `invoice_reference`
+
+Oznacza to, że po wznowieniu musisz nadal mieć ważny token dostępu:
+- przekazany jawnie do `resume_session(..., access_token=...)`, albo
+- ustawiony na kliencie: `KsefClient(..., access_token=...)`.
+
+## Publiczne API handle'a
+
+`OnlineSessionHandle` udostępnia:
+- `reference_number`
+- `session_reference_number` jako alias kompatybilności
+- `valid_until`
+- `form_code`
+- `encryption_data`
+- `get_state()`
+- `send_invoice()`
+- `get_status()`
+- `list_invoices()`
+- `list_failed_invoices()`
+- `get_invoice_status()`
+- `get_invoice_upo_by_ref()`
+- `get_invoice_upo_by_ksef()`
+- `get_upo()`
+- `close()`
+
+Zgodność wsteczna:
+- `OnlineSessionResult` pozostaje aliasem do `OnlineSessionHandle`,
+- kod używający `session_reference_number` i `encryption_data` nadal działa.
+
 ## Uwagi
 
-- `encryption_data` z `open_session()` musi być użyte dla wszystkich faktur wysyłanych w ramach sesji.
+- `encryption_data` z `open_session()` musi być użyte dla wszystkich faktur wysyłanych w ramach tej sesji; dlatego jest odtwarzane również przy `resume_session()`.
+- `resume_session()` odtwarza tylko stan sesji i materiał kryptograficzny. Statusy faktur wysłanych wcześniej trzeba śledzić osobno przez `invoice_reference`.
 - Dla `FA_RR (1)` w wersji `1-1E` przekazuj `formCode.value="FA_RR"` zamiast `RR`.
 - Status przetwarzania jest udostępniany asynchronicznie; sprawdzanie statusu odbywa się przez polling.
 - Pobranie UPO:
-  - dla faktury: `get_session_invoice_upo_by_ref()` / `...by_ksef()`
-  - dla sesji: `get_session_upo()`
+  - dla faktury: `get_invoice_upo_by_ref()` / `get_invoice_upo_by_ksef()`
+  - dla sesji: `get_upo()`
 - `upo_v43=True` dodaje nagłówek `X-KSeF-Feature: upo-v4-3` przy otwieraniu sesji.
+- `AsyncOnlineSessionWorkflow` i `AsyncOnlineSessionHandle` oferują lustrzane API asynchroniczne.

--- a/specs/ksef-openapi.snapshot.json
+++ b/specs/ksef-openapi.snapshot.json
@@ -14578,7 +14578,6 @@
         "enum": [
           "FA",
           "PEF",
-          "RR",
           "FA_RR"
         ],
         "type": "string",

--- a/src/ksef_client/cli/commands/send_cmd.py
+++ b/src/ksef_client/cli/commands/send_cmd.py
@@ -92,6 +92,11 @@ def send_online(
         "--save-upo",
         help="Save UPO to this path (requires --wait-upo).",
     ),
+    save_session: str | None = typer.Option(
+        None,
+        "--save-session",
+        help="Persist a resumable local session checkpoint under this id.",
+    ),
     save_upo_overwrite: bool = typer.Option(
         False,
         "--save-upo-overwrite",
@@ -119,6 +124,7 @@ def send_online(
             poll_interval=poll_interval,
             max_attempts=max_attempts,
             save_upo=save_upo,
+            save_session=save_session,
             save_upo_overwrite=save_upo_overwrite,
         )
     except Exception as exc:
@@ -157,6 +163,11 @@ def send_batch(
         "--save-upo",
         help="Save UPO to this path (requires --wait-upo).",
     ),
+    save_session: str | None = typer.Option(
+        None,
+        "--save-session",
+        help="Persist a resumable local session checkpoint under this id.",
+    ),
     save_upo_overwrite: bool = typer.Option(
         False,
         "--save-upo-overwrite",
@@ -186,6 +197,7 @@ def send_batch(
             poll_interval=poll_interval,
             max_attempts=max_attempts,
             save_upo=save_upo,
+            save_session=save_session,
             save_upo_overwrite=save_upo_overwrite,
         )
     except Exception as exc:

--- a/src/ksef_client/cli/commands/session_cmd.py
+++ b/src/ksef_client/cli/commands/session_cmd.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import os
+
+import typer
+
+from ksef_client.exceptions import KsefApiError, KsefHttpError, KsefRateLimitError
+
+from ..auth.manager import resolve_base_url
+from ..context import profile_label, require_context, require_profile
+from ..errors import CliError
+from ..exit_codes import ExitCode
+from ..output import get_renderer
+from ..sdk.session_ops import (
+    close_batch_session,
+    close_online_session,
+    drop_saved_session,
+    export_saved_session,
+    get_saved_session_status,
+    import_saved_session,
+    list_saved_sessions,
+    open_batch_session,
+    open_online_session,
+    send_online_session_invoice,
+    show_saved_session,
+    upload_batch_session,
+)
+from ._error_utils import build_api_error_hint, build_rate_limit_hint
+
+app = typer.Typer(help="Manage resumable online and batch sessions.")
+online_app = typer.Typer(help="Manage resumable online sessions.")
+batch_app = typer.Typer(help="Manage resumable batch sessions.")
+
+
+def _render_error(ctx: typer.Context, command: str, exc: Exception) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+
+    if isinstance(exc, CliError):
+        renderer.error(
+            command=command,
+            profile=profile_label(cli_ctx),
+            code=exc.code.name,
+            message=exc.message,
+            hint=exc.hint,
+        )
+        raise typer.Exit(int(exc.code))
+
+    if isinstance(exc, KsefRateLimitError):
+        hint = build_rate_limit_hint(exc, default_hint="Wait and retry.")
+        renderer.error(
+            command=command,
+            profile=profile_label(cli_ctx),
+            code="RATE_LIMIT",
+            message=str(exc),
+            hint=hint,
+        )
+        raise typer.Exit(int(ExitCode.RETRY_EXHAUSTED))
+
+    if isinstance(exc, (KsefApiError, KsefHttpError)):
+        hint = (
+            build_api_error_hint(exc, default_hint="Check KSeF response and request parameters.")
+            if isinstance(exc, KsefApiError)
+            else "Check KSeF response and request parameters."
+        )
+        renderer.error(
+            command=command,
+            profile=profile_label(cli_ctx),
+            code="API_ERROR",
+            message=str(exc),
+            hint=hint,
+        )
+        raise typer.Exit(int(ExitCode.API_ERROR))
+
+    renderer.error(
+        command=command,
+        profile=profile_label(cli_ctx),
+        code="UNEXPECTED",
+        message=str(exc),
+        hint="Run with -v and inspect logs.",
+    )
+    raise typer.Exit(int(ExitCode.CONFIG_ERROR))
+
+
+@app.command("list")
+def session_list(ctx: typer.Context) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = list_saved_sessions(profile=profile)
+    except Exception as exc:
+        _render_error(ctx, "session.list", exc)
+    renderer.success(command="session.list", profile=profile, data=result)
+
+
+@app.command("show")
+def session_show(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = show_saved_session(profile=profile, session_id=session_id)
+    except Exception as exc:
+        _render_error(ctx, "session.show", exc)
+    renderer.success(command="session.show", profile=profile, data=result)
+
+
+@app.command("status")
+def session_status(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    invoice_ref: str | None = typer.Option(
+        None, "--invoice-ref", help="Invoice reference for online-session invoice status."
+    ),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = get_saved_session_status(
+            profile=profile,
+            session_id=session_id,
+            invoice_ref=invoice_ref,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.status", exc)
+    renderer.success(command="session.status", profile=profile, data=result)
+
+
+@app.command("export")
+def session_export(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    out: str = typer.Option(..., "--out", help="Destination JSON path or directory."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = export_saved_session(profile=profile, session_id=session_id, out=out)
+    except Exception as exc:
+        _render_error(ctx, "session.export", exc)
+    renderer.success(command="session.export", profile=profile, data=result)
+
+
+@app.command("import")
+def session_import(
+    ctx: typer.Context,
+    source_path: str = typer.Option(..., "--in", help="Checkpoint JSON file to import."),
+    session_id: str | None = typer.Option(None, "--id", help="Override imported session id."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = import_saved_session(
+            profile=profile,
+            source_path=source_path,
+            session_id=session_id,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.import", exc)
+    renderer.success(command="session.import", profile=profile, data=result)
+
+
+@app.command("drop")
+def session_drop(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = drop_saved_session(profile=profile, session_id=session_id)
+    except Exception as exc:
+        _render_error(ctx, "session.drop", exc)
+    renderer.success(command="session.drop", profile=profile, data=result)
+
+
+@online_app.command("open")
+def session_online_open(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    system_code: str = typer.Option("FA (3)", "--system-code", help="Form code systemCode."),
+    schema_version: str = typer.Option("1-0E", "--schema-version", help="Form code schemaVersion."),
+    form_value: str = typer.Option(
+        "FA",
+        "--form-value",
+        help="Form code value (use FA_RR for FA_RR (1) 1-1E).",
+    ),
+    upo_v43: bool = typer.Option(False, "--upo-v43", help="Request UPO v4.3 format."),
+    base_url: str | None = typer.Option(
+        None, "--base-url", help="Override KSeF base URL for this command."
+    ),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = open_online_session(
+            profile=profile,
+            base_url=resolve_base_url(base_url or os.getenv("KSEF_BASE_URL"), profile=profile),
+            session_id=session_id,
+            system_code=system_code,
+            schema_version=schema_version,
+            form_value=form_value,
+            upo_v43=upo_v43,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.online.open", exc)
+    renderer.success(command="session.online.open", profile=profile, data=result)
+
+
+@online_app.command("send")
+def session_online_send(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    invoice: str = typer.Option(..., "--invoice", help="Path to invoice XML file."),
+    wait_status: bool = typer.Option(
+        False, "--wait-status", help="Wait until invoice processing status is final."
+    ),
+    wait_upo: bool = typer.Option(False, "--wait-upo", help="Wait until UPO becomes available."),
+    poll_interval: float = typer.Option(
+        2.0, "--poll-interval", help="Polling interval in seconds."
+    ),
+    max_attempts: int = typer.Option(60, "--max-attempts", help="Maximum polling attempts."),
+    save_upo: str | None = typer.Option(
+        None,
+        "--save-upo",
+        help="Save UPO to this path (requires --wait-upo).",
+    ),
+    save_upo_overwrite: bool = typer.Option(
+        False,
+        "--save-upo-overwrite",
+        help="Overwrite file specified by --save-upo when it already exists.",
+    ),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = send_online_session_invoice(
+            profile=profile,
+            session_id=session_id,
+            invoice=invoice,
+            wait_status=wait_status,
+            wait_upo=wait_upo,
+            poll_interval=poll_interval,
+            max_attempts=max_attempts,
+            save_upo=save_upo,
+            save_upo_overwrite=save_upo_overwrite,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.online.send", exc)
+    renderer.success(command="session.online.send", profile=profile, data=result)
+
+
+@online_app.command("close")
+def session_online_close(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = close_online_session(profile=profile, session_id=session_id)
+    except Exception as exc:
+        _render_error(ctx, "session.online.close", exc)
+    renderer.success(command="session.online.close", profile=profile, data=result)
+
+
+@batch_app.command("open")
+def session_batch_open(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    zip_path: str | None = typer.Option(None, "--zip", help="Path to input ZIP with invoices."),
+    directory: str | None = typer.Option(
+        None, "--dir", help="Directory with XML files to ZIP and upload."
+    ),
+    system_code: str = typer.Option("FA (3)", "--system-code", help="Form code systemCode."),
+    schema_version: str = typer.Option("1-0E", "--schema-version", help="Form code schemaVersion."),
+    form_value: str = typer.Option(
+        "FA",
+        "--form-value",
+        help="Form code value (use FA_RR for FA_RR (1) 1-1E).",
+    ),
+    upo_v43: bool = typer.Option(False, "--upo-v43", help="Request UPO v4.3 format."),
+    base_url: str | None = typer.Option(
+        None, "--base-url", help="Override KSeF base URL for this command."
+    ),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = open_batch_session(
+            profile=profile,
+            base_url=resolve_base_url(base_url or os.getenv("KSEF_BASE_URL"), profile=profile),
+            session_id=session_id,
+            zip_path=zip_path,
+            directory=directory,
+            system_code=system_code,
+            schema_version=schema_version,
+            form_value=form_value,
+            upo_v43=upo_v43,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.batch.open", exc)
+    renderer.success(command="session.batch.open", profile=profile, data=result)
+
+
+@batch_app.command("upload")
+def session_batch_upload(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    parallelism: int = typer.Option(4, "--parallelism", help="Parallel upload worker count."),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = upload_batch_session(
+            profile=profile,
+            session_id=session_id,
+            parallelism=parallelism,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.batch.upload", exc)
+    renderer.success(command="session.batch.upload", profile=profile, data=result)
+
+
+@batch_app.command("close")
+def session_batch_close(
+    ctx: typer.Context,
+    session_id: str = typer.Option(..., "--id", help="Saved session checkpoint id."),
+    wait_status: bool = typer.Option(
+        False, "--wait-status", help="Wait until batch session status is final."
+    ),
+    wait_upo: bool = typer.Option(
+        False, "--wait-upo", help="Wait until batch UPO becomes available."
+    ),
+    poll_interval: float = typer.Option(
+        2.0, "--poll-interval", help="Polling interval in seconds."
+    ),
+    max_attempts: int = typer.Option(120, "--max-attempts", help="Maximum polling attempts."),
+    save_upo: str | None = typer.Option(
+        None,
+        "--save-upo",
+        help="Save UPO to this path (requires --wait-upo).",
+    ),
+    save_upo_overwrite: bool = typer.Option(
+        False,
+        "--save-upo-overwrite",
+        help="Overwrite file specified by --save-upo when it already exists.",
+    ),
+) -> None:
+    cli_ctx = require_context(ctx)
+    renderer = get_renderer(cli_ctx)
+    profile = profile_label(cli_ctx)
+    try:
+        profile = require_profile(cli_ctx)
+        result = close_batch_session(
+            profile=profile,
+            session_id=session_id,
+            wait_status=wait_status,
+            wait_upo=wait_upo,
+            poll_interval=poll_interval,
+            max_attempts=max_attempts,
+            save_upo=save_upo,
+            save_upo_overwrite=save_upo_overwrite,
+        )
+    except Exception as exc:
+        _render_error(ctx, "session.batch.close", exc)
+    renderer.success(command="session.batch.close", profile=profile, data=result)
+
+
+app.add_typer(online_app, name="online")
+app.add_typer(batch_app, name="batch")

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -6,11 +6,11 @@ import time
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ksef_client import models as m
 from ksef_client.exceptions import KsefHttpError, KsefRateLimitError
-from ksef_client.services.crypto import EncryptionData, build_encryption_data
+from ksef_client.services.crypto import EncryptionData, build_encryption_data, get_file_metadata
 from ksef_client.services.workflows import (
     BatchSessionWorkflow,
     ExportWorkflow,
@@ -22,6 +22,13 @@ from ..auth.keyring_store import get_tokens
 from ..errors import CliError
 from ..exit_codes import ExitCode
 from ..policies.retry import RetryPolicy, compute_retry_delay_seconds, should_retry
+from ..session_store import (
+    BatchPayloadSource,
+    BatchSessionCheckpoint,
+    OnlineSessionCheckpoint,
+    save_checkpoint,
+    update_checkpoint,
+)
 from .factory import create_client
 
 _TRANSIENT_UPO_CODES = {404, 409, 425}
@@ -654,6 +661,27 @@ def _build_zip_from_directory(directory: str) -> bytes:
     return build_zip(files)
 
 
+def _build_batch_payload_source(
+    *,
+    zip_path: str | None,
+    directory: str | None,
+    zip_bytes: bytes,
+) -> BatchPayloadSource:
+    if zip_path:
+        path = str(Path(zip_path).resolve())
+        source_kind = "zip"
+    else:
+        path = str(Path(directory or "").resolve())
+        source_kind = "directory"
+    metadata = get_file_metadata(zip_bytes)
+    return BatchPayloadSource(
+        kind=source_kind,
+        path=path,
+        source_sha256_base64=metadata.sha256_base64,
+        source_size=metadata.file_size,
+    )
+
+
 def _validate_polling_options(poll_interval: float, max_attempts: int) -> None:
     if poll_interval <= 0:
         raise CliError(
@@ -1176,6 +1204,7 @@ def send_online_invoice(
     poll_interval: float,
     max_attempts: int,
     save_upo: str | None,
+    save_session: str | None = None,
     save_upo_overwrite: bool = False,
 ) -> dict[str, Any]:
     access_token = _require_access_token(profile)
@@ -1203,15 +1232,33 @@ def send_online_invoice(
             upo_v43=upo_v43,
         )
         session_ref = session.session_reference_number
+        checkpoint: OnlineSessionCheckpoint | None = None
+        if save_session is not None:
+            checkpoint = OnlineSessionCheckpoint(
+                id=save_session,
+                profile=profile,
+                base_url=base_url,
+                stage="opened",
+                session_state=session.get_state(),
+            )
+            try:
+                save_checkpoint(checkpoint, overwrite=False)
+            except Exception:
+                with suppress(Exception):
+                    session.close(access_token=access_token)
+                raise
 
         send_error: Exception | None = None
         try:
-            send_response = workflow.send_invoice(
-                session_reference_number=session_ref,
-                invoice_xml=invoice_xml,
-                encryption_data=session.encryption_data,
-                access_token=access_token,
-            )
+            if checkpoint is None:
+                send_response = workflow.send_invoice(
+                    session_reference_number=session_ref,
+                    invoice_xml=invoice_xml,
+                    encryption_data=session.encryption_data,
+                    access_token=access_token,
+                )
+            else:
+                send_response = session.send_invoice(invoice_xml, access_token=access_token)
             invoice_ref = _extract_reference_number(send_response)
             if not invoice_ref:
                 raise CliError(
@@ -1224,6 +1271,20 @@ def send_online_invoice(
                 "session_ref": session_ref,
                 "invoice_ref": invoice_ref,
             }
+            if checkpoint is not None:
+                sent_invoice_refs = list(checkpoint.sent_invoice_refs)
+                if invoice_ref not in sent_invoice_refs:
+                    sent_invoice_refs.append(invoice_ref)
+                checkpoint = cast(
+                    OnlineSessionCheckpoint,
+                    update_checkpoint(
+                        checkpoint,
+                        stage="invoice_sent",
+                        last_invoice_ref=invoice_ref,
+                        sent_invoice_refs=sent_invoice_refs,
+                    ),
+                )
+                result["session_id"] = checkpoint.id
 
             if wait_status or wait_upo:
                 status_payload = _wait_for_invoice_status(
@@ -1267,7 +1328,11 @@ def send_online_invoice(
             send_error = exc
             raise
         finally:
-            if send_error is None:
+            if checkpoint is not None:
+                if send_error is None:
+                    session.close(access_token=access_token)
+                    _ = update_checkpoint(checkpoint, stage="closed")
+            elif send_error is None:
                 workflow.close_session(session_ref, access_token)
             else:
                 with suppress(Exception):
@@ -1290,6 +1355,7 @@ def send_batch_invoices(
     poll_interval: float,
     max_attempts: int,
     save_upo: str | None,
+    save_session: str | None = None,
     save_upo_overwrite: bool = False,
 ) -> dict[str, Any]:
     access_token = _require_access_token(profile)
@@ -1319,23 +1385,85 @@ def send_batch_invoices(
     zip_bytes = (
         _load_batch_zip(zip_path or "") if zip_path else _build_zip_from_directory(directory or "")
     )
+    payload_source = _build_batch_payload_source(
+        zip_path=zip_path,
+        directory=directory,
+        zip_bytes=zip_bytes,
+    )
 
     with create_client(base_url, access_token=access_token) as client:
         certs = client.security.get_public_key_certificates()
         symmetric_cert = _select_certificate(certs, "SymmetricKeyEncryption")
         workflow = BatchSessionWorkflow(client.sessions, client.http_client)
-        session_ref = workflow.open_upload_and_close(
-            form_code=form_code,
-            zip_bytes=zip_bytes,
-            public_certificate=symmetric_cert,
-            access_token=access_token,
-            upo_v43=upo_v43,
-            parallelism=parallelism,
-        )
+        checkpoint: BatchSessionCheckpoint | None = None
+        if save_session is None:
+            session_ref = workflow.open_upload_and_close(
+                form_code=form_code,
+                zip_bytes=zip_bytes,
+                public_certificate=symmetric_cert,
+                access_token=access_token,
+                upo_v43=upo_v43,
+                parallelism=parallelism,
+            )
+        else:
+            session = workflow.open_session(
+                form_code=form_code,
+                zip_bytes=zip_bytes,
+                public_certificate=symmetric_cert,
+                access_token=access_token,
+                upo_v43=upo_v43,
+            )
+            checkpoint = BatchSessionCheckpoint(
+                id=save_session,
+                profile=profile,
+                base_url=base_url,
+                stage="opened",
+                session_state=session.get_state(),
+                payload_source=payload_source,
+            )
+            try:
+                save_checkpoint(checkpoint, overwrite=False)
+            except Exception:
+                with suppress(Exception):
+                    session.close(access_token=access_token)
+                raise
+
+            uploaded_ordinals: list[int] = []
+
+            def _progress(ordinal_number: int) -> None:
+                nonlocal checkpoint
+                if checkpoint is None:
+                    return
+                if ordinal_number not in uploaded_ordinals:
+                    uploaded_ordinals.append(ordinal_number)
+                    uploaded_ordinals.sort()
+                    checkpoint = cast(
+                        BatchSessionCheckpoint,
+                        update_checkpoint(
+                            checkpoint,
+                            stage="uploading",
+                            uploaded_ordinals=list(uploaded_ordinals),
+                        ),
+                    )
+
+            session.upload_parts(parallelism=parallelism, progress_callback=_progress)
+            checkpoint = cast(
+                BatchSessionCheckpoint,
+                update_checkpoint(
+                    checkpoint,
+                    stage="uploaded",
+                    uploaded_ordinals=list(uploaded_ordinals),
+                ),
+            )
+            session.close(access_token=access_token)
+            checkpoint = cast(BatchSessionCheckpoint, update_checkpoint(checkpoint, stage="closed"))
+            session_ref = session.reference_number
 
         result: dict[str, Any] = {
             "session_ref": session_ref,
         }
+        if checkpoint is not None:
+            result["session_id"] = checkpoint.id
 
         if wait_status or wait_upo:
             session_status = _wait_for_session_status(
@@ -1351,6 +1479,11 @@ def send_batch_invoices(
 
             upo_ref = _extract_upo_reference(session_status)
             result["upo_ref"] = str(upo_ref or "")
+            if checkpoint is not None:
+                checkpoint = cast(
+                    BatchSessionCheckpoint,
+                    update_checkpoint(checkpoint, last_upo_ref=str(upo_ref or "") or None),
+                )
 
             if wait_upo:
                 if not upo_ref:

--- a/src/ksef_client/cli/sdk/session_ops.py
+++ b/src/ksef_client/cli/sdk/session_ops.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, cast
+
+from ksef_client.services import BatchSessionHandle, BatchUploadHelper
+from ksef_client.services.crypto import get_file_metadata
+from ksef_client.services.workflows import BatchSessionWorkflow, OnlineSessionWorkflow
+
+from ..errors import CliError
+from ..exit_codes import ExitCode
+from ..session_store import (
+    BatchPayloadSource,
+    BatchSessionCheckpoint,
+    OnlineSessionCheckpoint,
+    SessionCheckpoint,
+    delete_checkpoint,
+    export_checkpoint,
+    import_checkpoint,
+    list_checkpoints,
+    load_checkpoint,
+    save_checkpoint,
+    update_checkpoint,
+)
+from . import adapters
+
+
+def _normalize_source_path(path: str) -> str:
+    return str(Path(path).resolve())
+
+
+def _build_batch_payload_source(
+    *,
+    zip_path: str | None,
+    directory: str | None,
+) -> tuple[bytes, BatchPayloadSource]:
+    selected = [bool(zip_path), bool(directory)]
+    if sum(1 for flag in selected if flag) != 1:
+        raise CliError(
+            "Select exactly one batch input source.",
+            ExitCode.VALIDATION_ERROR,
+            "Use one of: --zip or --dir.",
+        )
+
+    if zip_path:
+        normalized_path = _normalize_source_path(zip_path)
+        zip_bytes = adapters._load_batch_zip(normalized_path)
+        metadata = get_file_metadata(zip_bytes)
+        return zip_bytes, BatchPayloadSource(
+            kind="zip",
+            path=normalized_path,
+            source_sha256_base64=metadata.sha256_base64,
+            source_size=metadata.file_size,
+        )
+
+    normalized_path = _normalize_source_path(directory or "")
+    zip_bytes = adapters._build_zip_from_directory(normalized_path)
+    metadata = get_file_metadata(zip_bytes)
+    return zip_bytes, BatchPayloadSource(
+        kind="directory",
+        path=normalized_path,
+        source_sha256_base64=metadata.sha256_base64,
+        source_size=metadata.file_size,
+    )
+
+
+def _load_batch_source_bytes(source: BatchPayloadSource) -> bytes:
+    if source.kind == "zip":
+        zip_bytes = adapters._load_batch_zip(source.path)
+    else:
+        zip_bytes = adapters._build_zip_from_directory(source.path)
+
+    metadata = get_file_metadata(zip_bytes)
+    if (
+        metadata.file_size != source.source_size
+        or metadata.sha256_base64 != source.source_sha256_base64
+    ):
+        raise CliError(
+            "Batch payload source changed since session checkpoint was created.",
+            ExitCode.VALIDATION_ERROR,
+            "Restore the original ZIP/directory contents or open a new batch session.",
+        )
+    return zip_bytes
+
+
+def _require_online_checkpoint(profile: str, session_id: str) -> OnlineSessionCheckpoint:
+    checkpoint = load_checkpoint(profile, session_id)
+    if not isinstance(checkpoint, OnlineSessionCheckpoint):
+        raise CliError(
+            f"Session checkpoint '{session_id}' is not an online session.",
+            ExitCode.VALIDATION_ERROR,
+            "Use the batch subcommands for this checkpoint.",
+        )
+    return checkpoint
+
+
+def _require_batch_checkpoint(profile: str, session_id: str) -> BatchSessionCheckpoint:
+    checkpoint = load_checkpoint(profile, session_id)
+    if not isinstance(checkpoint, BatchSessionCheckpoint):
+        raise CliError(
+            f"Session checkpoint '{session_id}' is not a batch session.",
+            ExitCode.VALIDATION_ERROR,
+            "Use the online subcommands for this checkpoint.",
+        )
+    return checkpoint
+
+
+def _checkpoint_summary(checkpoint: SessionCheckpoint) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": checkpoint.id,
+        "kind": checkpoint.kind,
+        "profile": checkpoint.profile,
+        "base_url": checkpoint.base_url,
+        "stage": checkpoint.stage,
+        "created_at": checkpoint.created_at,
+        "updated_at": checkpoint.updated_at,
+        "session_ref": checkpoint.session_state.reference_number,
+    }
+    if isinstance(checkpoint, OnlineSessionCheckpoint):
+        payload["last_invoice_ref"] = checkpoint.last_invoice_ref or ""
+        payload["sent_invoice_count"] = len(checkpoint.sent_invoice_refs)
+    else:
+        payload["uploaded_ordinals"] = list(checkpoint.uploaded_ordinals)
+        payload["last_upo_ref"] = checkpoint.last_upo_ref or ""
+        payload["payload_source"] = checkpoint.payload_source.to_dict()
+    return payload
+
+
+def list_saved_sessions(*, profile: str) -> dict[str, Any]:
+    checkpoints = list_checkpoints(profile)
+    return {
+        "count": len(checkpoints),
+        "items": [_checkpoint_summary(checkpoint) for checkpoint in checkpoints],
+    }
+
+
+def show_saved_session(*, profile: str, session_id: str) -> dict[str, Any]:
+    checkpoint = load_checkpoint(profile, session_id)
+    return _checkpoint_summary(checkpoint) | {"checkpoint": checkpoint.to_dict()}
+
+
+def export_saved_session(*, profile: str, session_id: str, out: str) -> dict[str, Any]:
+    target = export_checkpoint(profile, session_id, Path(out))
+    return {
+        "id": session_id,
+        "profile": profile,
+        "path": str(target),
+    }
+
+
+def import_saved_session(
+    *,
+    profile: str,
+    source_path: str,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    checkpoint = import_checkpoint(profile, Path(source_path), session_id=session_id)
+    return _checkpoint_summary(checkpoint)
+
+
+def drop_saved_session(*, profile: str, session_id: str) -> dict[str, Any]:
+    delete_checkpoint(profile, session_id)
+    return {"id": session_id, "profile": profile, "deleted": True}
+
+
+def open_online_session(
+    *,
+    profile: str,
+    base_url: str,
+    session_id: str,
+    system_code: str,
+    schema_version: str,
+    form_value: str,
+    upo_v43: bool,
+) -> dict[str, Any]:
+    access_token = adapters._require_access_token(profile)
+    form_code = adapters._build_form_code(system_code, schema_version, form_value)
+
+    with adapters.create_client(base_url, access_token=access_token) as client:
+        certs = client.security.get_public_key_certificates()
+        symmetric_cert = adapters._select_certificate(certs, "SymmetricKeyEncryption")
+        workflow = OnlineSessionWorkflow(client.sessions)
+        session = workflow.open_session(
+            form_code=form_code,
+            public_certificate=symmetric_cert,
+            access_token=access_token,
+            upo_v43=upo_v43,
+        )
+        checkpoint = OnlineSessionCheckpoint(
+            id=session_id,
+            profile=profile,
+            base_url=base_url,
+            stage="opened",
+            session_state=session.get_state(),
+        )
+        try:
+            save_checkpoint(checkpoint, overwrite=False)
+        except Exception:
+            with suppress(Exception):
+                session.close(access_token=access_token)
+            raise
+
+    return _checkpoint_summary(checkpoint)
+
+
+def send_online_session_invoice(
+    *,
+    profile: str,
+    session_id: str,
+    invoice: str,
+    wait_status: bool,
+    wait_upo: bool,
+    poll_interval: float,
+    max_attempts: int,
+    save_upo: str | None,
+    save_upo_overwrite: bool = False,
+) -> dict[str, Any]:
+    checkpoint = _require_online_checkpoint(profile, session_id)
+    access_token = adapters._require_access_token(profile)
+    if save_upo and not wait_upo:
+        raise CliError(
+            "Option --save-upo requires --wait-upo.",
+            ExitCode.VALIDATION_ERROR,
+            "Use --wait-upo when saving UPO from session send command.",
+        )
+    if wait_status or wait_upo:
+        adapters._validate_polling_options(poll_interval, max_attempts)
+
+    invoice_xml = adapters._load_invoice_xml(invoice)
+    with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
+        workflow = OnlineSessionWorkflow(client.sessions)
+        session = workflow.resume_session(checkpoint.session_state, access_token=access_token)
+        send_response = session.send_invoice(invoice_xml, access_token=access_token)
+        invoice_ref = adapters._extract_reference_number(send_response)
+        if not invoice_ref:
+            raise CliError(
+                "Send response does not contain invoice reference number.",
+                ExitCode.API_ERROR,
+                "Check KSeF response payload.",
+            )
+
+        sent_invoice_refs = list(checkpoint.sent_invoice_refs)
+        if invoice_ref not in sent_invoice_refs:
+            sent_invoice_refs.append(invoice_ref)
+        checkpoint = cast(
+            OnlineSessionCheckpoint,
+            update_checkpoint(
+                checkpoint,
+                stage="invoice_sent",
+                last_invoice_ref=invoice_ref,
+                sent_invoice_refs=sent_invoice_refs,
+            ),
+        )
+
+        result: dict[str, Any] = {
+            "id": checkpoint.id,
+            "session_ref": checkpoint.session_state.reference_number,
+            "invoice_ref": invoice_ref,
+            "stage": checkpoint.stage,
+        }
+
+        if wait_status or wait_upo:
+            status_payload = adapters._wait_for_invoice_status(
+                client=client,
+                session_ref=checkpoint.session_state.reference_number,
+                invoice_ref=invoice_ref,
+                access_token=access_token,
+                poll_interval=poll_interval,
+                max_attempts=max_attempts,
+            )
+            code, description, _ = adapters._extract_status_fields(status_payload)
+            result["status_code"] = code
+            result["status_description"] = description
+            result["ksef_number"] = adapters._extract_ksef_number(status_payload)
+
+        if wait_upo:
+            upo_bytes = adapters._wait_for_invoice_upo(
+                client=client,
+                session_ref=checkpoint.session_state.reference_number,
+                invoice_ref=invoice_ref,
+                access_token=access_token,
+                poll_interval=poll_interval,
+                max_attempts=max_attempts,
+            )
+            result["upo_bytes"] = len(upo_bytes)
+            if save_upo:
+                upo_path = adapters._save_bytes(
+                    adapters._resolve_output_path(
+                        save_upo,
+                        default_filename=(
+                            f"upo-{checkpoint.session_state.reference_number}-{invoice_ref}.xml"
+                        ),
+                    ),
+                    upo_bytes,
+                    overwrite=save_upo_overwrite,
+                )
+                result["upo_path"] = str(upo_path)
+            else:
+                result["upo_path"] = ""
+
+    return result
+
+
+def close_online_session(
+    *,
+    profile: str,
+    session_id: str,
+) -> dict[str, Any]:
+    checkpoint = _require_online_checkpoint(profile, session_id)
+    access_token = adapters._require_access_token(profile)
+    with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
+        workflow = OnlineSessionWorkflow(client.sessions)
+        session = workflow.resume_session(checkpoint.session_state, access_token=access_token)
+        session.close(access_token=access_token)
+    checkpoint = cast(OnlineSessionCheckpoint, update_checkpoint(checkpoint, stage="closed"))
+    return _checkpoint_summary(checkpoint)
+
+
+def open_batch_session(
+    *,
+    profile: str,
+    base_url: str,
+    session_id: str,
+    zip_path: str | None,
+    directory: str | None,
+    system_code: str,
+    schema_version: str,
+    form_value: str,
+    upo_v43: bool,
+) -> dict[str, Any]:
+    access_token = adapters._require_access_token(profile)
+    form_code = adapters._build_form_code(system_code, schema_version, form_value)
+    zip_bytes, payload_source = _build_batch_payload_source(zip_path=zip_path, directory=directory)
+
+    with adapters.create_client(base_url, access_token=access_token) as client:
+        certs = client.security.get_public_key_certificates()
+        symmetric_cert = adapters._select_certificate(certs, "SymmetricKeyEncryption")
+        workflow = BatchSessionWorkflow(client.sessions, client.http_client)
+        session = workflow.open_session(
+            form_code=form_code,
+            zip_bytes=zip_bytes,
+            public_certificate=symmetric_cert,
+            access_token=access_token,
+            upo_v43=upo_v43,
+        )
+        checkpoint = BatchSessionCheckpoint(
+            id=session_id,
+            profile=profile,
+            base_url=base_url,
+            stage="opened",
+            session_state=session.get_state(),
+            payload_source=payload_source,
+        )
+        try:
+            save_checkpoint(checkpoint, overwrite=False)
+        except Exception:
+            with suppress(Exception):
+                session.close(access_token=access_token)
+            raise
+
+    return _checkpoint_summary(checkpoint)
+
+
+def upload_batch_session(
+    *,
+    profile: str,
+    session_id: str,
+    parallelism: int,
+) -> dict[str, Any]:
+    checkpoint = _require_batch_checkpoint(profile, session_id)
+    access_token = adapters._require_access_token(profile)
+    if parallelism <= 0:
+        raise CliError(
+            "Invalid parallelism.",
+            ExitCode.VALIDATION_ERROR,
+            "--parallelism must be greater than zero.",
+        )
+
+    zip_bytes = _load_batch_source_bytes(checkpoint.payload_source)
+    uploaded_ordinals = sorted(set(checkpoint.uploaded_ordinals))
+
+    with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
+        workflow = BatchSessionWorkflow(client.sessions, client.http_client)
+        session = workflow.resume_session(
+            checkpoint.session_state,
+            zip_bytes=zip_bytes,
+            access_token=access_token,
+        )
+
+        def _progress(ordinal_number: int) -> None:
+            nonlocal checkpoint
+            if ordinal_number not in uploaded_ordinals:
+                uploaded_ordinals.append(ordinal_number)
+                uploaded_ordinals.sort()
+                checkpoint = cast(
+                    BatchSessionCheckpoint,
+                    update_checkpoint(
+                        checkpoint,
+                        stage="uploading",
+                        uploaded_ordinals=list(uploaded_ordinals),
+                    ),
+                )
+
+        session.upload_parts(
+            parallelism=parallelism,
+            skip_ordinals=uploaded_ordinals,
+            progress_callback=_progress,
+        )
+
+    checkpoint = cast(
+        BatchSessionCheckpoint,
+        update_checkpoint(
+            checkpoint,
+            stage="uploaded",
+            uploaded_ordinals=list(uploaded_ordinals),
+        ),
+    )
+
+    return _checkpoint_summary(checkpoint) | {
+        "uploaded_count": len(uploaded_ordinals),
+        "total_parts": len(checkpoint.session_state.part_upload_requests),
+    }
+
+
+def close_batch_session(
+    *,
+    profile: str,
+    session_id: str,
+    wait_status: bool,
+    wait_upo: bool,
+    poll_interval: float,
+    max_attempts: int,
+    save_upo: str | None,
+    save_upo_overwrite: bool = False,
+) -> dict[str, Any]:
+    checkpoint = _require_batch_checkpoint(profile, session_id)
+    access_token = adapters._require_access_token(profile)
+    if save_upo and not wait_upo:
+        raise CliError(
+            "Option --save-upo requires --wait-upo.",
+            ExitCode.VALIDATION_ERROR,
+            "Use --wait-upo when saving UPO from session close command.",
+        )
+    if wait_status or wait_upo:
+        adapters._validate_polling_options(poll_interval, max_attempts)
+
+    with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
+        session = BatchSessionHandle.from_state(
+            checkpoint.session_state,
+            sessions_client=client.sessions,
+            uploader=BatchUploadHelper(client.http_client),
+            access_token=access_token,
+        )
+        session.close(access_token=access_token)
+        checkpoint = cast(BatchSessionCheckpoint, update_checkpoint(checkpoint, stage="closed"))
+
+        result: dict[str, Any] = _checkpoint_summary(checkpoint)
+        if wait_status or wait_upo:
+            session_status = adapters._wait_for_session_status(
+                client=client,
+                session_ref=checkpoint.session_state.reference_number,
+                access_token=access_token,
+                poll_interval=poll_interval,
+                max_attempts=max_attempts,
+            )
+            code, description, _ = adapters._extract_status_fields(session_status)
+            result["status_code"] = code
+            result["status_description"] = description
+            upo_ref = adapters._extract_upo_reference(session_status)
+            checkpoint = cast(
+                BatchSessionCheckpoint,
+                update_checkpoint(checkpoint, last_upo_ref=str(upo_ref or "") or None),
+            )
+            result["upo_ref"] = str(upo_ref or "")
+
+            if wait_upo:
+                if not upo_ref:
+                    raise CliError(
+                        "UPO reference number is not available in session status.",
+                        ExitCode.RETRY_EXHAUSTED,
+                        "Run `ksef upo wait --session-ref <SESSION_REF> --batch-auto` later.",
+                    )
+                upo_bytes = adapters._wait_for_batch_upo(
+                    client=client,
+                    session_ref=checkpoint.session_state.reference_number,
+                    upo_ref=str(upo_ref),
+                    access_token=access_token,
+                    poll_interval=poll_interval,
+                    max_attempts=max_attempts,
+                )
+                result["upo_bytes"] = len(upo_bytes)
+                if save_upo:
+                    upo_path = adapters._save_bytes(
+                        adapters._resolve_output_path(
+                            save_upo,
+                            default_filename=(
+                                f"upo-{checkpoint.session_state.reference_number}-{upo_ref}.xml"
+                            ),
+                        ),
+                        upo_bytes,
+                        overwrite=save_upo_overwrite,
+                    )
+                    result["upo_path"] = str(upo_path)
+                else:
+                    result["upo_path"] = ""
+
+    return result
+
+
+def get_saved_session_status(
+    *,
+    profile: str,
+    session_id: str,
+    invoice_ref: str | None,
+) -> dict[str, Any]:
+    checkpoint = load_checkpoint(profile, session_id)
+    return adapters.get_send_status(
+        profile=profile,
+        base_url=checkpoint.base_url,
+        session_ref=checkpoint.session_state.reference_number,
+        invoice_ref=invoice_ref,
+    ) | {"id": checkpoint.id, "kind": checkpoint.kind, "stage": checkpoint.stage}

--- a/src/ksef_client/cli/session_store.py
+++ b/src/ksef_client/cli/session_store.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+from .config.paths import cache_dir
+from .errors import CliError
+from .exit_codes import ExitCode
+
+_CHECKPOINT_SCHEMA_VERSION = 1
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_session_id(session_id: str) -> str:
+    normalized = session_id.strip()
+    if not _SESSION_ID_RE.fullmatch(normalized):
+        raise CliError(
+            "Invalid session id.",
+            ExitCode.VALIDATION_ERROR,
+            "Use 1-128 characters from: letters, digits, dot, dash, underscore.",
+        )
+    return normalized
+
+
+def _checkpoint_root() -> Path:
+    return cache_dir() / "sessions"
+
+
+def _profile_dir(profile: str) -> Path:
+    return _checkpoint_root() / profile
+
+
+def _checkpoint_path(profile: str, session_id: str) -> Path:
+    safe_id = _validate_session_id(session_id)
+    return _profile_dir(profile) / f"{safe_id}.json"
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    data = json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True)
+    try:
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            with suppress(OSError):
+                os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        with suppress(OSError):
+            tmp_path.unlink()
+        raise CliError(
+            "Cannot persist session checkpoint.",
+            ExitCode.CONFIG_ERROR,
+            "Grant write access to CLI cache directory.",
+        ) from exc
+    if os.name != "nt":
+        with suppress(OSError):
+            os.chmod(path, 0o600)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CliError(
+            f"Cannot read session checkpoint: {path}",
+            ExitCode.CONFIG_ERROR,
+            "The checkpoint file is missing or invalid JSON.",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise CliError(
+            f"Invalid session checkpoint payload: {path}",
+            ExitCode.CONFIG_ERROR,
+            "The checkpoint file must contain a JSON object.",
+        )
+    return raw
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid {field_name}: expected string or null.")
+    return value
+
+
+def _required_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError(f"Invalid {field_name}: expected non-empty string.")
+    return value
+
+
+def _required_int(value: Any, *, field_name: str) -> int:
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"Invalid {field_name}: expected non-negative integer.")
+    return value
+
+
+def _required_string_list(value: Any, *, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"Invalid {field_name}: expected JSON array.")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"Invalid {field_name}: expected array of strings.")
+        result.append(item)
+    return result
+
+
+def _required_int_list(value: Any, *, field_name: str) -> list[int]:
+    if not isinstance(value, list):
+        raise ValueError(f"Invalid {field_name}: expected JSON array.")
+    result: list[int] = []
+    for item in value:
+        if not isinstance(item, int) or item < 0:
+            raise ValueError(f"Invalid {field_name}: expected array of non-negative integers.")
+        result.append(item)
+    return result
+
+
+@dataclass(frozen=True)
+class BatchPayloadSource:
+    kind: str
+    path: str
+    source_sha256_base64: str
+    source_size: int
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"zip", "directory"}:
+            raise ValueError(f"Invalid payload source kind: {self.kind!r}.")
+        if self.path.strip() == "":
+            raise ValueError("Invalid payload source path: expected non-empty string.")
+        if self.source_size < 0:
+            raise ValueError("Invalid source_size: expected non-negative integer.")
+        if self.source_sha256_base64.strip() == "":
+            raise ValueError("Invalid source_sha256_base64: expected non-empty string.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "source_sha256_base64": self.source_sha256_base64,
+            "source_size": self.source_size,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> BatchPayloadSource:
+        return cls(
+            kind=_required_string(payload.get("kind"), field_name="payload_source.kind"),
+            path=_required_string(payload.get("path"), field_name="payload_source.path"),
+            source_sha256_base64=_required_string(
+                payload.get("source_sha256_base64"),
+                field_name="payload_source.source_sha256_base64",
+            ),
+            source_size=_required_int(
+                payload.get("source_size"),
+                field_name="payload_source.source_size",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class OnlineSessionCheckpoint:
+    id: str
+    profile: str
+    base_url: str
+    stage: str
+    session_state: OnlineSessionState
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+    last_invoice_ref: str | None = None
+    sent_invoice_refs: list[str] = field(default_factory=list)
+    schema_version: int = _CHECKPOINT_SCHEMA_VERSION
+    kind: str = "online"
+
+    def __post_init__(self) -> None:
+        _ = _validate_session_id(self.id)
+        if self.schema_version != _CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported checkpoint schema_version: {self.schema_version!r}."
+            )
+        if self.kind != "online":
+            raise ValueError(f"Invalid checkpoint kind: {self.kind!r}.")
+        if self.profile.strip() == "":
+            raise ValueError("Invalid profile: expected non-empty string.")
+        if self.base_url.strip() == "":
+            raise ValueError("Invalid base_url: expected non-empty string.")
+        if self.stage.strip() == "":
+            raise ValueError("Invalid stage: expected non-empty string.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "id": self.id,
+            "profile": self.profile,
+            "base_url": self.base_url,
+            "kind": self.kind,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "stage": self.stage,
+            "session_state": self.session_state.to_dict(),
+            "last_invoice_ref": self.last_invoice_ref,
+            "sent_invoice_refs": list(self.sent_invoice_refs),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> OnlineSessionCheckpoint:
+        if payload.get("schema_version") != _CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported checkpoint schema_version: "
+                f"{payload.get('schema_version')!r}."
+            )
+        if payload.get("kind") != "online":
+            raise ValueError(f"Invalid checkpoint kind: {payload.get('kind')!r}.")
+        session_payload = payload.get("session_state")
+        if not isinstance(session_payload, dict):
+            raise ValueError("Invalid session_state: expected JSON object.")
+        return cls(
+            id=_required_string(payload.get("id"), field_name="id"),
+            profile=_required_string(payload.get("profile"), field_name="profile"),
+            base_url=_required_string(payload.get("base_url"), field_name="base_url"),
+            kind="online",
+            created_at=_required_string(payload.get("created_at"), field_name="created_at"),
+            updated_at=_required_string(payload.get("updated_at"), field_name="updated_at"),
+            stage=_required_string(payload.get("stage"), field_name="stage"),
+            session_state=OnlineSessionState.from_dict(session_payload),
+            last_invoice_ref=_optional_string(
+                payload.get("last_invoice_ref"),
+                field_name="last_invoice_ref",
+            ),
+            sent_invoice_refs=_required_string_list(
+                payload.get("sent_invoice_refs", []),
+                field_name="sent_invoice_refs",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class BatchSessionCheckpoint:
+    id: str
+    profile: str
+    base_url: str
+    stage: str
+    session_state: BatchSessionState
+    payload_source: BatchPayloadSource
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+    uploaded_ordinals: list[int] = field(default_factory=list)
+    last_upo_ref: str | None = None
+    schema_version: int = _CHECKPOINT_SCHEMA_VERSION
+    kind: str = "batch"
+
+    def __post_init__(self) -> None:
+        _ = _validate_session_id(self.id)
+        if self.schema_version != _CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported checkpoint schema_version: {self.schema_version!r}."
+            )
+        if self.kind != "batch":
+            raise ValueError(f"Invalid checkpoint kind: {self.kind!r}.")
+        if self.profile.strip() == "":
+            raise ValueError("Invalid profile: expected non-empty string.")
+        if self.base_url.strip() == "":
+            raise ValueError("Invalid base_url: expected non-empty string.")
+        if self.stage.strip() == "":
+            raise ValueError("Invalid stage: expected non-empty string.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "id": self.id,
+            "profile": self.profile,
+            "base_url": self.base_url,
+            "kind": self.kind,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "stage": self.stage,
+            "session_state": self.session_state.to_dict(),
+            "payload_source": self.payload_source.to_dict(),
+            "uploaded_ordinals": list(self.uploaded_ordinals),
+            "last_upo_ref": self.last_upo_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> BatchSessionCheckpoint:
+        if payload.get("schema_version") != _CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported checkpoint schema_version: "
+                f"{payload.get('schema_version')!r}."
+            )
+        if payload.get("kind") != "batch":
+            raise ValueError(f"Invalid checkpoint kind: {payload.get('kind')!r}.")
+        session_payload = payload.get("session_state")
+        if not isinstance(session_payload, dict):
+            raise ValueError("Invalid session_state: expected JSON object.")
+        source_payload = payload.get("payload_source")
+        if not isinstance(source_payload, dict):
+            raise ValueError("Invalid payload_source: expected JSON object.")
+        return cls(
+            id=_required_string(payload.get("id"), field_name="id"),
+            profile=_required_string(payload.get("profile"), field_name="profile"),
+            base_url=_required_string(payload.get("base_url"), field_name="base_url"),
+            kind="batch",
+            created_at=_required_string(payload.get("created_at"), field_name="created_at"),
+            updated_at=_required_string(payload.get("updated_at"), field_name="updated_at"),
+            stage=_required_string(payload.get("stage"), field_name="stage"),
+            session_state=BatchSessionState.from_dict(session_payload),
+            payload_source=BatchPayloadSource.from_dict(source_payload),
+            uploaded_ordinals=_required_int_list(
+                payload.get("uploaded_ordinals", []),
+                field_name="uploaded_ordinals",
+            ),
+            last_upo_ref=_optional_string(payload.get("last_upo_ref"), field_name="last_upo_ref"),
+        )
+
+
+SessionCheckpoint = OnlineSessionCheckpoint | BatchSessionCheckpoint
+
+
+def checkpoint_from_dict(payload: dict[str, Any]) -> SessionCheckpoint:
+    kind = payload.get("kind")
+    try:
+        if kind == "online":
+            return OnlineSessionCheckpoint.from_dict(payload)
+        if kind == "batch":
+            return BatchSessionCheckpoint.from_dict(payload)
+    except ValueError as exc:
+        raise CliError(
+            "Invalid session checkpoint payload.",
+            ExitCode.CONFIG_ERROR,
+            str(exc),
+        ) from exc
+    raise CliError(
+        "Invalid session checkpoint payload.",
+        ExitCode.CONFIG_ERROR,
+        f"Unsupported checkpoint kind: {kind!r}.",
+    )
+
+
+def save_checkpoint(checkpoint: SessionCheckpoint, *, overwrite: bool = True) -> Path:
+    path = _checkpoint_path(checkpoint.profile, checkpoint.id)
+    if path.exists() and not overwrite:
+        raise CliError(
+            f"Session checkpoint '{checkpoint.id}' already exists.",
+            ExitCode.VALIDATION_ERROR,
+            "Choose a different --id or overwrite the existing checkpoint.",
+        )
+    _write_json_atomic(path, checkpoint.to_dict())
+    return path
+
+
+def load_checkpoint(profile: str, session_id: str) -> SessionCheckpoint:
+    path = _checkpoint_path(profile, session_id)
+    if not path.exists():
+        raise CliError(
+            f"Session checkpoint '{session_id}' does not exist.",
+            ExitCode.CONFIG_ERROR,
+            "Create it first with `ksef session ... open` or `ksef send ... --save-session`.",
+        )
+    return checkpoint_from_dict(_read_json(path))
+
+
+def list_checkpoints(profile: str) -> list[SessionCheckpoint]:
+    directory = _profile_dir(profile)
+    if not directory.exists():
+        return []
+    checkpoints: list[SessionCheckpoint] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            checkpoints.append(checkpoint_from_dict(_read_json(path)))
+        except CliError:
+            continue
+    return checkpoints
+
+
+def delete_checkpoint(profile: str, session_id: str) -> None:
+    path = _checkpoint_path(profile, session_id)
+    if not path.exists():
+        raise CliError(
+            f"Session checkpoint '{session_id}' does not exist.",
+            ExitCode.CONFIG_ERROR,
+            "Nothing to delete.",
+        )
+    try:
+        path.unlink()
+    except OSError as exc:
+        raise CliError(
+            "Cannot delete session checkpoint.",
+            ExitCode.CONFIG_ERROR,
+            "Check filesystem permissions and try again.",
+        ) from exc
+
+
+def update_checkpoint(
+    checkpoint: SessionCheckpoint,
+    **changes: Any,
+) -> SessionCheckpoint:
+    updated = replace(checkpoint, **changes, updated_at=_now_iso())
+    save_checkpoint(updated, overwrite=True)
+    return updated
+
+
+def export_checkpoint(profile: str, session_id: str, out_path: Path) -> Path:
+    checkpoint = load_checkpoint(profile, session_id)
+    target = out_path
+    if target.exists() and target.is_dir():
+        target = target / f"session-{checkpoint.id}.json"
+    if str(out_path).replace("\\", "/").endswith("/"):
+        target = Path(str(out_path).replace("\\", "/")) / f"session-{checkpoint.id}.json"
+    _write_json_atomic(target, checkpoint.to_dict())
+    return target
+
+
+def import_checkpoint(
+    profile: str,
+    source_path: Path,
+    *,
+    session_id: str | None = None,
+) -> SessionCheckpoint:
+    if not source_path.exists() or not source_path.is_file():
+        raise CliError(
+            f"Checkpoint file does not exist: {source_path}",
+            ExitCode.IO_ERROR,
+            "Use --in with an existing JSON checkpoint file.",
+        )
+    checkpoint = checkpoint_from_dict(_read_json(source_path))
+    if checkpoint.profile != profile:
+        raise CliError(
+            "Checkpoint profile does not match selected profile.",
+            ExitCode.VALIDATION_ERROR,
+            f"Checkpoint profile is '{checkpoint.profile}', selected profile is '{profile}'.",
+        )
+    if session_id is not None:
+        checkpoint = replace(checkpoint, id=_validate_session_id(session_id))
+    save_checkpoint(checkpoint, overwrite=True)
+    return checkpoint
+
+
+__all__ = [
+    "BatchPayloadSource",
+    "OnlineSessionCheckpoint",
+    "BatchSessionCheckpoint",
+    "SessionCheckpoint",
+    "checkpoint_from_dict",
+    "save_checkpoint",
+    "load_checkpoint",
+    "list_checkpoints",
+    "delete_checkpoint",
+    "update_checkpoint",
+    "export_checkpoint",
+    "import_checkpoint",
+]

--- a/src/ksef_client/cli/typer_app.py
+++ b/src/ksef_client/cli/typer_app.py
@@ -13,6 +13,7 @@ from .commands import (
     lighthouse_cmd,
     profile_cmd,
     send_cmd,
+    session_cmd,
     upo_cmd,
 )
 from .config.loader import load_config
@@ -83,6 +84,7 @@ app.add_typer(health_cmd.app, name="health")
 app.add_typer(lighthouse_cmd.app, name="lighthouse")
 app.add_typer(invoice_cmd.app, name="invoice")
 app.add_typer(send_cmd.app, name="send")
+app.add_typer(session_cmd.app, name="session")
 app.add_typer(upo_cmd.app, name="upo")
 app.add_typer(export_cmd.app, name="export")
 app.command("init")(init_cmd.init_command)

--- a/src/ksef_client/clients/sessions.py
+++ b/src/ksef_client/clients/sessions.py
@@ -71,7 +71,7 @@ class SessionsClient(BaseApiClient):
         self,
         request_payload: OpenOnlineSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenOnlineSessionResponse:
         headers = {}
@@ -87,7 +87,9 @@ class SessionsClient(BaseApiClient):
             expected_status={201},
         )
 
-    def close_online_session(self, reference_number: str, access_token: str) -> None:
+    def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None:
         self._request_json(
             "POST",
             f"/sessions/online/{reference_number}/close",
@@ -100,7 +102,7 @@ class SessionsClient(BaseApiClient):
         reference_number: str,
         request_payload: SendInvoiceRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SendInvoiceResponse:
         return self._request_model(
             "POST",
@@ -115,7 +117,7 @@ class SessionsClient(BaseApiClient):
         self,
         request_payload: OpenBatchSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenBatchSessionResponse:
         headers = {}
@@ -131,7 +133,7 @@ class SessionsClient(BaseApiClient):
             expected_status={201},
         )
 
-    def close_batch_session(self, reference_number: str, access_token: str) -> None:
+    def close_batch_session(self, reference_number: str, access_token: str | None = None) -> None:
         self._request_json(
             "POST",
             f"/sessions/batch/{reference_number}/close",
@@ -139,7 +141,9 @@ class SessionsClient(BaseApiClient):
             expected_status={204},
         )
 
-    def get_session_status(self, reference_number: str, access_token: str) -> SessionStatusResponse:
+    def get_session_status(
+        self, reference_number: str, access_token: str | None = None
+    ) -> SessionStatusResponse:
         return self._request_model(
             "GET",
             f"/sessions/{reference_number}",
@@ -153,7 +157,7 @@ class SessionsClient(BaseApiClient):
         *,
         page_size: int | None = None,
         continuation_token: str | None = None,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoicesResponse:
         headers = {}
         if continuation_token:
@@ -176,7 +180,7 @@ class SessionsClient(BaseApiClient):
         *,
         page_size: int | None = None,
         continuation_token: str | None = None,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoicesResponse:
         headers = {}
         if continuation_token:
@@ -198,7 +202,7 @@ class SessionsClient(BaseApiClient):
         reference_number: str,
         invoice_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoiceStatusResponse:
         return self._request_model(
             "GET",
@@ -212,7 +216,7 @@ class SessionsClient(BaseApiClient):
         reference_number: str,
         invoice_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return self._request_bytes(
             "GET",
@@ -225,7 +229,7 @@ class SessionsClient(BaseApiClient):
         reference_number: str,
         ksef_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return self._request_bytes(
             "GET",
@@ -238,7 +242,7 @@ class SessionsClient(BaseApiClient):
         reference_number: str,
         upo_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return self._request_bytes(
             "GET",
@@ -301,7 +305,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         self,
         request_payload: OpenOnlineSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenOnlineSessionResponse:
         headers = {}
@@ -317,7 +321,9 @@ class AsyncSessionsClient(AsyncBaseApiClient):
             expected_status={201},
         )
 
-    async def close_online_session(self, reference_number: str, access_token: str) -> None:
+    async def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None:
         await self._request_json(
             "POST",
             f"/sessions/online/{reference_number}/close",
@@ -330,7 +336,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         reference_number: str,
         request_payload: SendInvoiceRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SendInvoiceResponse:
         return await self._request_model(
             "POST",
@@ -345,7 +351,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         self,
         request_payload: OpenBatchSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenBatchSessionResponse:
         headers = {}
@@ -361,7 +367,9 @@ class AsyncSessionsClient(AsyncBaseApiClient):
             expected_status={201},
         )
 
-    async def close_batch_session(self, reference_number: str, access_token: str) -> None:
+    async def close_batch_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None:
         await self._request_json(
             "POST",
             f"/sessions/batch/{reference_number}/close",
@@ -370,7 +378,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         )
 
     async def get_session_status(
-        self, reference_number: str, access_token: str
+        self, reference_number: str, access_token: str | None = None
     ) -> SessionStatusResponse:
         return await self._request_model(
             "GET",
@@ -385,7 +393,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         *,
         page_size: int | None = None,
         continuation_token: str | None = None,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoicesResponse:
         headers = {}
         if continuation_token:
@@ -408,7 +416,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         *,
         page_size: int | None = None,
         continuation_token: str | None = None,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoicesResponse:
         headers = {}
         if continuation_token:
@@ -430,7 +438,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         reference_number: str,
         invoice_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SessionInvoiceStatusResponse:
         return await self._request_model(
             "GET",
@@ -444,7 +452,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         reference_number: str,
         invoice_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return await self._request_bytes(
             "GET",
@@ -457,7 +465,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         reference_number: str,
         ksef_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return await self._request_bytes(
             "GET",
@@ -470,7 +478,7 @@ class AsyncSessionsClient(AsyncBaseApiClient):
         reference_number: str,
         upo_reference_number: str,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> bytes:
         return await self._request_bytes(
             "GET",

--- a/src/ksef_client/openapi_models.py
+++ b/src/ksef_client/openapi_models.py
@@ -458,7 +458,6 @@ class InvoiceQueryDateType(OpenApiEnum):
 class InvoiceQueryFormType(OpenApiEnum):
     FA = "FA"
     PEF = "PEF"
-    RR = "RR"
     FA_RR = "FA_RR"
 
 class InvoiceQuerySubjectType(OpenApiEnum):

--- a/src/ksef_client/services/__init__.py
+++ b/src/ksef_client/services/__init__.py
@@ -17,6 +17,14 @@ from .csr import CsrResult, generate_csr_ec, generate_csr_rsa
 from .hwm import dedupe_by_ksef_number, get_effective_start_date, update_continuation_point
 from .person_token import PersonToken, PersonTokenService
 from .qr import add_label_to_qr, generate_qr_png, resize_png
+from .sessions import (
+    AsyncBatchSessionHandle,
+    AsyncOnlineSessionHandle,
+    BatchSessionHandle,
+    BatchSessionState,
+    OnlineSessionHandle,
+    OnlineSessionState,
+)
 from .verification_link import VerificationLinkService
 from .workflows import (
     AsyncAuthCoordinator,
@@ -60,6 +68,12 @@ __all__ = [
     "XadesKeyPair",
     "BatchUploadHelper",
     "AsyncBatchUploadHelper",
+    "OnlineSessionState",
+    "BatchSessionState",
+    "OnlineSessionHandle",
+    "BatchSessionHandle",
+    "AsyncOnlineSessionHandle",
+    "AsyncBatchSessionHandle",
     "ExportDownloadHelper",
     "AsyncExportDownloadHelper",
     "AuthCoordinator",

--- a/src/ksef_client/services/sessions.py
+++ b/src/ksef_client/services/sessions.py
@@ -1,0 +1,1053 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .. import models as m
+from .batch import encrypt_batch_parts
+from .crypto import EncryptionData, build_send_invoice_request
+
+_SESSION_STATE_SCHEMA_VERSION = 1
+
+
+def _encode_base64(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode_base64(value: str, *, field_name: str) -> bytes:
+    try:
+        return base64.b64decode(value.encode("ascii"), validate=True)
+    except (ValueError, UnicodeEncodeError, binascii.Error) as exc:
+        raise ValueError(f"Invalid {field_name}: expected Base64 data.") from exc
+
+
+def _require_dict(value: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid {field_name}: expected JSON object.")
+    return value
+
+
+def _require_list(value: Any, *, field_name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"Invalid {field_name}: expected JSON array.")
+    return value
+
+
+def _validate_session_header(*, payload: dict[str, Any], kind: str) -> None:
+    schema_version = payload.get("schema_version")
+    if schema_version != _SESSION_STATE_SCHEMA_VERSION:
+        raise ValueError(
+            "Unsupported session state schema_version: "
+            f"{schema_version!r}. Expected {_SESSION_STATE_SCHEMA_VERSION}."
+        )
+    payload_kind = payload.get("kind")
+    if payload_kind != kind:
+        raise ValueError(f"Invalid session state kind: {payload_kind!r}. Expected {kind!r}.")
+
+
+def _serialize_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+class _SessionsClient(Protocol):
+    def send_online_invoice(
+        self,
+        reference_number: str,
+        request_payload: m.SendInvoiceRequest,
+        *,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse: ...
+
+    def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
+
+    def close_batch_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
+
+    def get_session_status(
+        self, reference_number: str, access_token: str | None = None
+    ) -> m.SessionStatusResponse: ...
+
+    def get_session_invoices(
+        self,
+        reference_number: str,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse: ...
+
+    def get_session_failed_invoices(
+        self,
+        reference_number: str,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse: ...
+
+    def get_session_invoice_status(
+        self,
+        reference_number: str,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> m.SessionInvoiceStatusResponse: ...
+
+    def get_session_invoice_upo_by_ref(
+        self,
+        reference_number: str,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+    def get_session_invoice_upo_by_ksef(
+        self,
+        reference_number: str,
+        ksef_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+    def get_session_upo(
+        self,
+        reference_number: str,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+
+class _AsyncSessionsClient(Protocol):
+    async def send_online_invoice(
+        self,
+        reference_number: str,
+        request_payload: m.SendInvoiceRequest,
+        *,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse: ...
+
+    async def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
+
+    async def close_batch_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
+
+    async def get_session_status(
+        self, reference_number: str, access_token: str | None = None
+    ) -> m.SessionStatusResponse: ...
+
+    async def get_session_invoices(
+        self,
+        reference_number: str,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse: ...
+
+    async def get_session_failed_invoices(
+        self,
+        reference_number: str,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse: ...
+
+    async def get_session_invoice_status(
+        self,
+        reference_number: str,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> m.SessionInvoiceStatusResponse: ...
+
+    async def get_session_invoice_upo_by_ref(
+        self,
+        reference_number: str,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+    async def get_session_invoice_upo_by_ksef(
+        self,
+        reference_number: str,
+        ksef_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+    async def get_session_upo(
+        self,
+        reference_number: str,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes: ...
+
+
+class _BatchUploader(Protocol):
+    def upload_parts(
+        self,
+        part_upload_requests: list[m.PartUploadRequest],
+        parts: Sequence[bytes] | Sequence[tuple[int, bytes]],
+        *,
+        parallelism: int = 1,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> None: ...
+
+
+class _AsyncBatchUploader(Protocol):
+    async def upload_parts(
+        self,
+        part_upload_requests: list[m.PartUploadRequest],
+        parts: Sequence[bytes] | Sequence[tuple[int, bytes]],
+        *,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class OnlineSessionState:
+    reference_number: str
+    form_code: m.FormCode
+    valid_until: str | None
+    symmetric_key_base64: str
+    iv_base64: str
+    upo_v43: bool = False
+    schema_version: int = _SESSION_STATE_SCHEMA_VERSION
+    kind: str = "online"
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _SESSION_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported session state schema_version: "
+                f"{self.schema_version!r}. Expected {_SESSION_STATE_SCHEMA_VERSION}."
+            )
+        if self.kind != "online":
+            raise ValueError(f"Invalid session state kind: {self.kind!r}. Expected 'online'.")
+        _ = self.symmetric_key
+        _ = self.iv
+
+    @property
+    def symmetric_key(self) -> bytes:
+        return _decode_base64(self.symmetric_key_base64, field_name="symmetric_key_base64")
+
+    @property
+    def iv(self) -> bytes:
+        return _decode_base64(self.iv_base64, field_name="iv_base64")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "reference_number": self.reference_number,
+            "form_code": self.form_code.to_dict(),
+            "valid_until": self.valid_until,
+            "symmetric_key_base64": self.symmetric_key_base64,
+            "iv_base64": self.iv_base64,
+            "upo_v43": self.upo_v43,
+        }
+
+    def to_json(self) -> str:
+        return _serialize_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> OnlineSessionState:
+        _validate_session_header(payload=payload, kind="online")
+        form_code_payload = _require_dict(payload.get("form_code"), field_name="form_code")
+        reference_number = payload.get("reference_number")
+        if not isinstance(reference_number, str) or reference_number.strip() == "":
+            raise ValueError("Invalid reference_number: expected non-empty string.")
+        valid_until = payload.get("valid_until")
+        if valid_until is not None and not isinstance(valid_until, str):
+            raise ValueError("Invalid valid_until: expected string or null.")
+        symmetric_key_base64 = payload.get("symmetric_key_base64")
+        if not isinstance(symmetric_key_base64, str):
+            raise ValueError("Invalid symmetric_key_base64: expected string.")
+        iv_base64 = payload.get("iv_base64")
+        if not isinstance(iv_base64, str):
+            raise ValueError("Invalid iv_base64: expected string.")
+        return cls(
+            reference_number=reference_number,
+            form_code=m.FormCode.from_dict(form_code_payload),
+            valid_until=valid_until,
+            symmetric_key_base64=symmetric_key_base64,
+            iv_base64=iv_base64,
+            upo_v43=bool(payload.get("upo_v43", False)),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> OnlineSessionState:
+        data = json.loads(payload)
+        return cls.from_dict(_require_dict(data, field_name="session state"))
+
+    @classmethod
+    def from_runtime(
+        cls,
+        *,
+        reference_number: str,
+        form_code: m.FormCode,
+        valid_until: str | None,
+        encryption_data: EncryptionData,
+        upo_v43: bool,
+    ) -> OnlineSessionState:
+        return cls(
+            reference_number=reference_number,
+            form_code=form_code,
+            valid_until=valid_until,
+            symmetric_key_base64=_encode_base64(encryption_data.key),
+            iv_base64=_encode_base64(encryption_data.iv),
+            upo_v43=upo_v43,
+        )
+
+
+@dataclass(frozen=True)
+class BatchSessionState:
+    reference_number: str
+    form_code: m.FormCode
+    batch_file: m.BatchFileInfo
+    part_upload_requests: list[m.PartUploadRequest]
+    symmetric_key_base64: str
+    iv_base64: str
+    upo_v43: bool = False
+    offline_mode: bool | None = None
+    schema_version: int = _SESSION_STATE_SCHEMA_VERSION
+    kind: str = "batch"
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _SESSION_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported session state schema_version: "
+                f"{self.schema_version!r}. Expected {_SESSION_STATE_SCHEMA_VERSION}."
+            )
+        if self.kind != "batch":
+            raise ValueError(f"Invalid session state kind: {self.kind!r}. Expected 'batch'.")
+        _ = self.symmetric_key
+        _ = self.iv
+
+    @property
+    def symmetric_key(self) -> bytes:
+        return _decode_base64(self.symmetric_key_base64, field_name="symmetric_key_base64")
+
+    @property
+    def iv(self) -> bytes:
+        return _decode_base64(self.iv_base64, field_name="iv_base64")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "reference_number": self.reference_number,
+            "form_code": self.form_code.to_dict(),
+            "batch_file": self.batch_file.to_dict(),
+            "part_upload_requests": [item.to_dict() for item in self.part_upload_requests],
+            "symmetric_key_base64": self.symmetric_key_base64,
+            "iv_base64": self.iv_base64,
+            "upo_v43": self.upo_v43,
+            "offline_mode": self.offline_mode,
+        }
+
+    def to_json(self) -> str:
+        return _serialize_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> BatchSessionState:
+        _validate_session_header(payload=payload, kind="batch")
+        form_code_payload = _require_dict(payload.get("form_code"), field_name="form_code")
+        batch_file_payload = _require_dict(payload.get("batch_file"), field_name="batch_file")
+        requests_payload = _require_list(
+            payload.get("part_upload_requests"),
+            field_name="part_upload_requests",
+        )
+        reference_number = payload.get("reference_number")
+        if not isinstance(reference_number, str) or reference_number.strip() == "":
+            raise ValueError("Invalid reference_number: expected non-empty string.")
+        symmetric_key_base64 = payload.get("symmetric_key_base64")
+        if not isinstance(symmetric_key_base64, str):
+            raise ValueError("Invalid symmetric_key_base64: expected string.")
+        iv_base64 = payload.get("iv_base64")
+        if not isinstance(iv_base64, str):
+            raise ValueError("Invalid iv_base64: expected string.")
+        offline_mode = payload.get("offline_mode")
+        if offline_mode is not None and not isinstance(offline_mode, bool):
+            raise ValueError("Invalid offline_mode: expected bool or null.")
+        return cls(
+            reference_number=reference_number,
+            form_code=m.FormCode.from_dict(form_code_payload),
+            batch_file=m.BatchFileInfo.from_dict(batch_file_payload),
+            part_upload_requests=[
+                m.PartUploadRequest.from_dict(
+                    _require_dict(item, field_name="part_upload_requests[]")
+                )
+                for item in requests_payload
+            ],
+            symmetric_key_base64=symmetric_key_base64,
+            iv_base64=iv_base64,
+            upo_v43=bool(payload.get("upo_v43", False)),
+            offline_mode=offline_mode,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> BatchSessionState:
+        data = json.loads(payload)
+        return cls.from_dict(_require_dict(data, field_name="session state"))
+
+    @classmethod
+    def from_runtime(
+        cls,
+        *,
+        reference_number: str,
+        form_code: m.FormCode,
+        batch_file: m.BatchFileInfo,
+        part_upload_requests: list[m.PartUploadRequest],
+        encryption_data: EncryptionData,
+        upo_v43: bool,
+        offline_mode: bool | None,
+    ) -> BatchSessionState:
+        return cls(
+            reference_number=reference_number,
+            form_code=form_code,
+            batch_file=batch_file,
+            part_upload_requests=list(part_upload_requests),
+            symmetric_key_base64=_encode_base64(encryption_data.key),
+            iv_base64=_encode_base64(encryption_data.iv),
+            upo_v43=upo_v43,
+            offline_mode=offline_mode,
+        )
+
+
+def _resolve_access_token(
+    explicit_access_token: str | None,
+    default_access_token: str | None,
+) -> str | None:
+    return explicit_access_token if explicit_access_token is not None else default_access_token
+
+
+def _restore_encryption_data(
+    *, symmetric_key_base64: str, iv_base64: str, encryption_info: m.EncryptionInfo | None = None
+) -> EncryptionData:
+    return EncryptionData(
+        key=_decode_base64(symmetric_key_base64, field_name="symmetric_key_base64"),
+        iv=_decode_base64(iv_base64, field_name="iv_base64"),
+        encryption_info=encryption_info,
+    )
+
+
+@dataclass(frozen=True)
+class OnlineSessionHandle:
+    _sessions: _SessionsClient
+    reference_number: str
+    form_code: m.FormCode
+    valid_until: str | None
+    encryption_data: EncryptionData
+    _access_token: str | None = None
+    upo_v43: bool = False
+
+    @property
+    def session_reference_number(self) -> str:
+        return self.reference_number
+
+    def get_state(self) -> OnlineSessionState:
+        return OnlineSessionState.from_runtime(
+            reference_number=self.reference_number,
+            form_code=self.form_code,
+            valid_until=self.valid_until,
+            encryption_data=self.encryption_data,
+            upo_v43=self.upo_v43,
+        )
+
+    def send_invoice(
+        self,
+        invoice_xml: bytes,
+        *,
+        offline_mode: bool | None = None,
+        hash_of_corrected_invoice: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse:
+        request_payload = build_send_invoice_request(
+            invoice_xml,
+            self.encryption_data.key,
+            self.encryption_data.iv,
+            offline_mode=offline_mode,
+            hash_of_corrected_invoice=hash_of_corrected_invoice,
+        )
+        return self._sessions.send_online_invoice(
+            self.reference_number,
+            request_payload,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_status(self, *, access_token: str | None = None) -> m.SessionStatusResponse:
+        return self._sessions.get_session_status(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def list_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return self._sessions.get_session_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def list_failed_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return self._sessions.get_session_failed_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_invoice_status(
+        self,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> m.SessionInvoiceStatusResponse:
+        return self._sessions.get_session_invoice_status(
+            self.reference_number,
+            invoice_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_invoice_upo_by_ref(
+        self,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return self._sessions.get_session_invoice_upo_by_ref(
+            self.reference_number,
+            invoice_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_invoice_upo_by_ksef(
+        self,
+        ksef_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return self._sessions.get_session_invoice_upo_by_ksef(
+            self.reference_number,
+            ksef_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_upo(
+        self,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return self._sessions.get_session_upo(
+            self.reference_number,
+            upo_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def close(self, *, access_token: str | None = None) -> None:
+        self._sessions.close_online_session(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    @classmethod
+    def from_state(
+        cls,
+        state: OnlineSessionState,
+        *,
+        sessions_client: _SessionsClient,
+        access_token: str | None = None,
+    ) -> OnlineSessionHandle:
+        return cls(
+            _sessions=sessions_client,
+            reference_number=state.reference_number,
+            form_code=state.form_code,
+            valid_until=state.valid_until,
+            encryption_data=_restore_encryption_data(
+                symmetric_key_base64=state.symmetric_key_base64,
+                iv_base64=state.iv_base64,
+            ),
+            _access_token=access_token,
+            upo_v43=state.upo_v43,
+        )
+
+
+@dataclass(frozen=True)
+class AsyncOnlineSessionHandle:
+    _sessions: _AsyncSessionsClient
+    reference_number: str
+    form_code: m.FormCode
+    valid_until: str | None
+    encryption_data: EncryptionData
+    _access_token: str | None = None
+    upo_v43: bool = False
+
+    @property
+    def session_reference_number(self) -> str:
+        return self.reference_number
+
+    def get_state(self) -> OnlineSessionState:
+        return OnlineSessionState.from_runtime(
+            reference_number=self.reference_number,
+            form_code=self.form_code,
+            valid_until=self.valid_until,
+            encryption_data=self.encryption_data,
+            upo_v43=self.upo_v43,
+        )
+
+    async def send_invoice(
+        self,
+        invoice_xml: bytes,
+        *,
+        offline_mode: bool | None = None,
+        hash_of_corrected_invoice: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse:
+        request_payload = build_send_invoice_request(
+            invoice_xml,
+            self.encryption_data.key,
+            self.encryption_data.iv,
+            offline_mode=offline_mode,
+            hash_of_corrected_invoice=hash_of_corrected_invoice,
+        )
+        return await self._sessions.send_online_invoice(
+            self.reference_number,
+            request_payload,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_status(self, *, access_token: str | None = None) -> m.SessionStatusResponse:
+        return await self._sessions.get_session_status(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def list_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return await self._sessions.get_session_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def list_failed_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return await self._sessions.get_session_failed_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_invoice_status(
+        self,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> m.SessionInvoiceStatusResponse:
+        return await self._sessions.get_session_invoice_status(
+            self.reference_number,
+            invoice_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_invoice_upo_by_ref(
+        self,
+        invoice_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return await self._sessions.get_session_invoice_upo_by_ref(
+            self.reference_number,
+            invoice_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_invoice_upo_by_ksef(
+        self,
+        ksef_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return await self._sessions.get_session_invoice_upo_by_ksef(
+            self.reference_number,
+            ksef_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_upo(
+        self,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return await self._sessions.get_session_upo(
+            self.reference_number,
+            upo_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def close(self, *, access_token: str | None = None) -> None:
+        await self._sessions.close_online_session(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    @classmethod
+    def from_state(
+        cls,
+        state: OnlineSessionState,
+        *,
+        sessions_client: _AsyncSessionsClient,
+        access_token: str | None = None,
+    ) -> AsyncOnlineSessionHandle:
+        return cls(
+            _sessions=sessions_client,
+            reference_number=state.reference_number,
+            form_code=state.form_code,
+            valid_until=state.valid_until,
+            encryption_data=_restore_encryption_data(
+                symmetric_key_base64=state.symmetric_key_base64,
+                iv_base64=state.iv_base64,
+            ),
+            _access_token=access_token,
+            upo_v43=state.upo_v43,
+        )
+
+
+def _indexed_parts(parts: Sequence[bytes]) -> list[tuple[int, bytes]]:
+    return [(index, part) for index, part in enumerate(parts, start=1)]
+
+
+@dataclass(frozen=True)
+class BatchSessionHandle:
+    _sessions: _SessionsClient
+    _uploader: _BatchUploader
+    reference_number: str
+    form_code: m.FormCode
+    batch_file: m.BatchFileInfo
+    part_upload_requests: list[m.PartUploadRequest]
+    encryption_data: EncryptionData
+    _access_token: str | None = None
+    upo_v43: bool = False
+    offline_mode: bool | None = None
+    _encrypted_parts: list[tuple[int, bytes]] | None = None
+
+    @property
+    def session_reference_number(self) -> str:
+        return self.reference_number
+
+    def get_state(self) -> BatchSessionState:
+        return BatchSessionState.from_runtime(
+            reference_number=self.reference_number,
+            form_code=self.form_code,
+            batch_file=self.batch_file,
+            part_upload_requests=self.part_upload_requests,
+            encryption_data=self.encryption_data,
+            upo_v43=self.upo_v43,
+            offline_mode=self.offline_mode,
+        )
+
+    def upload_parts(
+        self,
+        *,
+        parallelism: int = 1,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> None:
+        if self._encrypted_parts is None:
+            raise ValueError(
+                "Batch session handle has no prepared parts attached. "
+                "Resume the session with zip_bytes or open it via "
+                "BatchSessionWorkflow.open_session()."
+            )
+        self._uploader.upload_parts(
+            self.part_upload_requests,
+            self._encrypted_parts,
+            parallelism=parallelism,
+            skip_ordinals=skip_ordinals,
+            progress_callback=progress_callback,
+        )
+
+    def get_status(self, *, access_token: str | None = None) -> m.SessionStatusResponse:
+        return self._sessions.get_session_status(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def list_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return self._sessions.get_session_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def list_failed_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return self._sessions.get_session_failed_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def get_upo(
+        self,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return self._sessions.get_session_upo(
+            self.reference_number,
+            upo_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    def close(self, *, access_token: str | None = None) -> None:
+        self._sessions.close_batch_session(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    @classmethod
+    def from_state(
+        cls,
+        state: BatchSessionState,
+        *,
+        sessions_client: _SessionsClient,
+        uploader: _BatchUploader,
+        access_token: str | None = None,
+        zip_bytes: bytes | None = None,
+    ) -> BatchSessionHandle:
+        encryption_data = _restore_encryption_data(
+            symmetric_key_base64=state.symmetric_key_base64,
+            iv_base64=state.iv_base64,
+        )
+        encrypted_parts: list[tuple[int, bytes]] | None = None
+        if zip_bytes is not None:
+            prepared_parts, prepared_batch_file = encrypt_batch_parts(
+                zip_bytes,
+                encryption_data.key,
+                encryption_data.iv,
+            )
+            if prepared_batch_file.to_dict() != state.batch_file.to_dict():
+                raise ValueError(
+                    "Provided ZIP content does not match stored batch session state."
+                )
+            encrypted_parts = _indexed_parts(prepared_parts)
+        return cls(
+            _sessions=sessions_client,
+            _uploader=uploader,
+            reference_number=state.reference_number,
+            form_code=state.form_code,
+            batch_file=state.batch_file,
+            part_upload_requests=list(state.part_upload_requests),
+            encryption_data=encryption_data,
+            _access_token=access_token,
+            upo_v43=state.upo_v43,
+            offline_mode=state.offline_mode,
+            _encrypted_parts=encrypted_parts,
+        )
+
+
+@dataclass(frozen=True)
+class AsyncBatchSessionHandle:
+    _sessions: _AsyncSessionsClient
+    _uploader: _AsyncBatchUploader
+    reference_number: str
+    form_code: m.FormCode
+    batch_file: m.BatchFileInfo
+    part_upload_requests: list[m.PartUploadRequest]
+    encryption_data: EncryptionData
+    _access_token: str | None = None
+    upo_v43: bool = False
+    offline_mode: bool | None = None
+    _encrypted_parts: list[tuple[int, bytes]] | None = None
+
+    @property
+    def session_reference_number(self) -> str:
+        return self.reference_number
+
+    def get_state(self) -> BatchSessionState:
+        return BatchSessionState.from_runtime(
+            reference_number=self.reference_number,
+            form_code=self.form_code,
+            batch_file=self.batch_file,
+            part_upload_requests=self.part_upload_requests,
+            encryption_data=self.encryption_data,
+            upo_v43=self.upo_v43,
+            offline_mode=self.offline_mode,
+        )
+
+    async def upload_parts(
+        self,
+        *,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> None:
+        if self._encrypted_parts is None:
+            raise ValueError(
+                "Batch session handle has no prepared parts attached. "
+                "Resume the session with zip_bytes or open it via "
+                "AsyncBatchSessionWorkflow.open_session()."
+            )
+        await self._uploader.upload_parts(
+            self.part_upload_requests,
+            self._encrypted_parts,
+            skip_ordinals=skip_ordinals,
+            progress_callback=progress_callback,
+        )
+
+    async def get_status(self, *, access_token: str | None = None) -> m.SessionStatusResponse:
+        return await self._sessions.get_session_status(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def list_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return await self._sessions.get_session_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def list_failed_invoices(
+        self,
+        *,
+        page_size: int | None = None,
+        continuation_token: str | None = None,
+        access_token: str | None = None,
+    ) -> m.SessionInvoicesResponse:
+        return await self._sessions.get_session_failed_invoices(
+            self.reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def get_upo(
+        self,
+        upo_reference_number: str,
+        *,
+        access_token: str | None = None,
+    ) -> bytes:
+        return await self._sessions.get_session_upo(
+            self.reference_number,
+            upo_reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    async def close(self, *, access_token: str | None = None) -> None:
+        await self._sessions.close_batch_session(
+            self.reference_number,
+            access_token=_resolve_access_token(access_token, self._access_token),
+        )
+
+    @classmethod
+    def from_state(
+        cls,
+        state: BatchSessionState,
+        *,
+        sessions_client: _AsyncSessionsClient,
+        uploader: _AsyncBatchUploader,
+        access_token: str | None = None,
+        zip_bytes: bytes | None = None,
+    ) -> AsyncBatchSessionHandle:
+        encryption_data = _restore_encryption_data(
+            symmetric_key_base64=state.symmetric_key_base64,
+            iv_base64=state.iv_base64,
+        )
+        encrypted_parts: list[tuple[int, bytes]] | None = None
+        if zip_bytes is not None:
+            prepared_parts, prepared_batch_file = encrypt_batch_parts(
+                zip_bytes,
+                encryption_data.key,
+                encryption_data.iv,
+            )
+            if prepared_batch_file.to_dict() != state.batch_file.to_dict():
+                raise ValueError(
+                    "Provided ZIP content does not match stored batch session state."
+                )
+            encrypted_parts = _indexed_parts(prepared_parts)
+        return cls(
+            _sessions=sessions_client,
+            _uploader=uploader,
+            reference_number=state.reference_number,
+            form_code=state.form_code,
+            batch_file=state.batch_file,
+            part_upload_requests=list(state.part_upload_requests),
+            encryption_data=encryption_data,
+            _access_token=access_token,
+            upo_v43=state.upo_v43,
+            offline_mode=state.offline_mode,
+            _encrypted_parts=encrypted_parts,
+        )
+
+
+__all__ = [
+    "OnlineSessionState",
+    "BatchSessionState",
+    "OnlineSessionHandle",
+    "BatchSessionHandle",
+    "AsyncOnlineSessionHandle",
+    "AsyncBatchSessionHandle",
+]

--- a/src/ksef_client/services/workflows.py
+++ b/src/ksef_client/services/workflows.py
@@ -4,8 +4,8 @@ import asyncio
 import base64
 import hashlib
 import time
-from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Collection, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
@@ -39,6 +39,15 @@ from .crypto import (
     build_send_invoice_request,
     decrypt_aes_cbc_pkcs7,
 )
+from .sessions import (
+    AsyncBatchSessionHandle,
+    AsyncOnlineSessionHandle,
+    BatchSessionHandle,
+    BatchSessionState,
+    OnlineSessionHandle,
+    OnlineSessionState,
+    _indexed_parts,
+)
 from .xades import XadesKeyPair
 
 
@@ -55,7 +64,7 @@ class _SessionsClient(Protocol):
         self,
         request_payload: OpenOnlineSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenOnlineSessionResponse: ...
 
@@ -64,20 +73,24 @@ class _SessionsClient(Protocol):
         reference_number: str,
         request_payload: SendInvoiceRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SendInvoiceResponse: ...
 
-    def close_online_session(self, reference_number: str, access_token: str) -> None: ...
+    def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
 
     def open_batch_session(
         self,
         request_payload: OpenBatchSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenBatchSessionResponse: ...
 
-    def close_batch_session(self, reference_number: str, access_token: str) -> None: ...
+    def close_batch_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
 
 
 class _AsyncSessionsClient(Protocol):
@@ -85,7 +98,7 @@ class _AsyncSessionsClient(Protocol):
         self,
         request_payload: OpenOnlineSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenOnlineSessionResponse: ...
 
@@ -94,20 +107,24 @@ class _AsyncSessionsClient(Protocol):
         reference_number: str,
         request_payload: SendInvoiceRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
     ) -> SendInvoiceResponse: ...
 
-    async def close_online_session(self, reference_number: str, access_token: str) -> None: ...
+    async def close_online_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
 
     async def open_batch_session(
         self,
         request_payload: OpenBatchSessionRequest,
         *,
-        access_token: str,
+        access_token: str | None = None,
         upo_v43: bool = False,
     ) -> OpenBatchSessionResponse: ...
 
-    async def close_batch_session(self, reference_number: str, access_token: str) -> None: ...
+    async def close_batch_session(
+        self, reference_number: str, access_token: str | None = None
+    ) -> None: ...
 
 
 class _AuthClient(Protocol):
@@ -164,11 +181,18 @@ class BatchUploadHelper:
         parts: Sequence[bytes] | Sequence[tuple[int, bytes]],
         *,
         parallelism: int = 1,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> None:
         if len(part_upload_requests) != len(parts):
             raise ValueError("parts length must match part_upload_requests length")
 
-        pairs = _pair_requests_with_parts(part_upload_requests, parts)
+        skip_set = {int(ordinal) for ordinal in (skip_ordinals or [])}
+        pairs = [
+            (req, part)
+            for req, part in _pair_requests_with_parts(part_upload_requests, parts)
+            if req.ordinal_number not in skip_set
+        ]
 
         def _send(req: PartUploadRequest, content: bytes) -> None:
             self._http.request(
@@ -183,12 +207,16 @@ class BatchUploadHelper:
         if parallelism <= 1:
             for req, part in pairs:
                 _send(req, part)
+                if progress_callback is not None:
+                    progress_callback(req.ordinal_number)
             return
 
         with ThreadPoolExecutor(max_workers=parallelism) as executor:
-            futures = [executor.submit(_send, req, part) for req, part in pairs]
-            for fut in futures:
+            futures = {executor.submit(_send, req, part): req.ordinal_number for req, part in pairs}
+            for fut in as_completed(futures):
                 fut.result()
+                if progress_callback is not None:
+                    progress_callback(futures[fut])
 
 
 class AsyncBatchUploadHelper:
@@ -199,11 +227,19 @@ class AsyncBatchUploadHelper:
         self,
         part_upload_requests: list[PartUploadRequest],
         parts: Sequence[bytes] | Sequence[tuple[int, bytes]],
+        *,
+        skip_ordinals: Collection[int] | None = None,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> None:
         if len(part_upload_requests) != len(parts):
             raise ValueError("parts length must match part_upload_requests length")
 
-        pairs = _pair_requests_with_parts(part_upload_requests, parts)
+        skip_set = {int(ordinal) for ordinal in (skip_ordinals or [])}
+        pairs = [
+            (req, part)
+            for req, part in _pair_requests_with_parts(part_upload_requests, parts)
+            if req.ordinal_number not in skip_set
+        ]
 
         async def _send(req: PartUploadRequest, content: bytes) -> None:
             await self._http.request(
@@ -215,8 +251,15 @@ class AsyncBatchUploadHelper:
                 expected_status={200, 201},
             )
 
-        tasks = [asyncio.create_task(_send(req, part)) for req, part in pairs]
-        await asyncio.gather(*tasks)
+        async def _send_with_ordinal(req: PartUploadRequest, content: bytes) -> int:
+            await _send(req, content)
+            return req.ordinal_number
+
+        tasks = [asyncio.create_task(_send_with_ordinal(req, part)) for req, part in pairs]
+        for task in asyncio.as_completed(tasks):
+            ordinal_number = await task
+            if progress_callback is not None:
+                progress_callback(ordinal_number)
 
 
 @dataclass(frozen=True)
@@ -508,10 +551,7 @@ class AsyncAuthCoordinator:
         raise TimeoutError("Authentication did not complete within max_attempts")
 
 
-@dataclass(frozen=True)
-class OnlineSessionResult:
-    session_reference_number: str
-    encryption_data: EncryptionData
+OnlineSessionResult = OnlineSessionHandle
 
 
 class OnlineSessionWorkflow:
@@ -525,7 +565,7 @@ class OnlineSessionWorkflow:
         public_certificate: str,
         access_token: str,
         upo_v43: bool = False,
-    ) -> OnlineSessionResult:
+    ) -> OnlineSessionHandle:
         encryption = build_encryption_data(public_certificate)
         response = self._sessions.open_online_session(
             OpenOnlineSessionRequest(
@@ -535,9 +575,26 @@ class OnlineSessionWorkflow:
             access_token=access_token,
             upo_v43=upo_v43,
         )
-        return OnlineSessionResult(
-            session_reference_number=response.reference_number,
+        return OnlineSessionHandle(
+            _sessions=self._sessions,
+            reference_number=response.reference_number,
+            form_code=form_code,
+            valid_until=response.valid_until,
             encryption_data=encryption,
+            _access_token=access_token,
+            upo_v43=upo_v43,
+        )
+
+    def resume_session(
+        self,
+        state: OnlineSessionState,
+        *,
+        access_token: str | None = None,
+    ) -> OnlineSessionHandle:
+        return OnlineSessionHandle.from_state(
+            state,
+            sessions_client=self._sessions,
+            access_token=access_token,
         )
 
     def send_invoice(
@@ -578,7 +635,7 @@ class AsyncOnlineSessionWorkflow:
         public_certificate: str,
         access_token: str,
         upo_v43: bool = False,
-    ) -> OnlineSessionResult:
+    ) -> AsyncOnlineSessionHandle:
         encryption = build_encryption_data(public_certificate)
         response = await self._sessions.open_online_session(
             OpenOnlineSessionRequest(
@@ -588,9 +645,26 @@ class AsyncOnlineSessionWorkflow:
             access_token=access_token,
             upo_v43=upo_v43,
         )
-        return OnlineSessionResult(
-            session_reference_number=response.reference_number,
+        return AsyncOnlineSessionHandle(
+            _sessions=self._sessions,
+            reference_number=response.reference_number,
+            form_code=form_code,
+            valid_until=response.valid_until,
             encryption_data=encryption,
+            _access_token=access_token,
+            upo_v43=upo_v43,
+        )
+
+    def resume_session(
+        self,
+        state: OnlineSessionState,
+        *,
+        access_token: str | None = None,
+    ) -> AsyncOnlineSessionHandle:
+        return AsyncOnlineSessionHandle.from_state(
+            state,
+            sessions_client=self._sessions,
+            access_token=access_token,
         )
 
     async def send_invoice(
@@ -625,7 +699,7 @@ class BatchSessionWorkflow:
         self._sessions = sessions_client
         self._upload_helper = BatchUploadHelper(http_client)
 
-    def open_upload_and_close(
+    def open_session(
         self,
         *,
         form_code: FormCode,
@@ -634,8 +708,7 @@ class BatchSessionWorkflow:
         access_token: str,
         offline_mode: bool | None = None,
         upo_v43: bool = False,
-        parallelism: int = 1,
-    ) -> str:
+    ) -> BatchSessionHandle:
         encryption = build_encryption_data(public_certificate)
         encrypted_parts, batch_file_info = encrypt_batch_parts(
             zip_bytes, encryption.key, encryption.iv
@@ -650,24 +723,36 @@ class BatchSessionWorkflow:
             access_token=access_token,
             upo_v43=upo_v43,
         )
-        self._upload_helper.upload_parts(
-            response.part_upload_requests,
-            encrypted_parts,
-            parallelism=parallelism,
+        return BatchSessionHandle(
+            _sessions=self._sessions,
+            _uploader=self._upload_helper,
+            reference_number=response.reference_number,
+            form_code=form_code,
+            batch_file=batch_file_info,
+            part_upload_requests=response.part_upload_requests,
+            encryption_data=encryption,
+            _access_token=access_token,
+            upo_v43=upo_v43,
+            offline_mode=offline_mode,
+            _encrypted_parts=_indexed_parts(encrypted_parts),
         )
-        reference_number = response.reference_number
-        self._sessions.close_batch_session(reference_number, access_token=access_token)
-        return reference_number
 
+    def resume_session(
+        self,
+        state: BatchSessionState,
+        *,
+        zip_bytes: bytes,
+        access_token: str | None = None,
+    ) -> BatchSessionHandle:
+        return BatchSessionHandle.from_state(
+            state,
+            sessions_client=self._sessions,
+            uploader=self._upload_helper,
+            access_token=access_token,
+            zip_bytes=zip_bytes,
+        )
 
-class AsyncBatchSessionWorkflow:
-    def __init__(
-        self, sessions_client: _AsyncSessionsClient, http_client: _AsyncRequestHttpClient
-    ) -> None:
-        self._sessions = sessions_client
-        self._upload_helper = AsyncBatchUploadHelper(http_client)
-
-    async def open_upload_and_close(
+    def open_upload_and_close(
         self,
         *,
         form_code: FormCode,
@@ -678,6 +763,36 @@ class AsyncBatchSessionWorkflow:
         upo_v43: bool = False,
         parallelism: int = 1,
     ) -> str:
+        session = self.open_session(
+            form_code=form_code,
+            zip_bytes=zip_bytes,
+            public_certificate=public_certificate,
+            access_token=access_token,
+            offline_mode=offline_mode,
+            upo_v43=upo_v43,
+        )
+        session.upload_parts(parallelism=parallelism)
+        session.close(access_token=access_token)
+        return session.reference_number
+
+
+class AsyncBatchSessionWorkflow:
+    def __init__(
+        self, sessions_client: _AsyncSessionsClient, http_client: _AsyncRequestHttpClient
+    ) -> None:
+        self._sessions = sessions_client
+        self._upload_helper = AsyncBatchUploadHelper(http_client)
+
+    async def open_session(
+        self,
+        *,
+        form_code: FormCode,
+        zip_bytes: bytes,
+        public_certificate: str,
+        access_token: str,
+        offline_mode: bool | None = None,
+        upo_v43: bool = False,
+    ) -> AsyncBatchSessionHandle:
         encryption = build_encryption_data(public_certificate)
         encrypted_parts, batch_file_info = encrypt_batch_parts(
             zip_bytes, encryption.key, encryption.iv
@@ -692,10 +807,58 @@ class AsyncBatchSessionWorkflow:
             access_token=access_token,
             upo_v43=upo_v43,
         )
-        await self._upload_helper.upload_parts(response.part_upload_requests, encrypted_parts)
-        reference_number = response.reference_number
-        await self._sessions.close_batch_session(reference_number, access_token=access_token)
-        return reference_number
+        return AsyncBatchSessionHandle(
+            _sessions=self._sessions,
+            _uploader=self._upload_helper,
+            reference_number=response.reference_number,
+            form_code=form_code,
+            batch_file=batch_file_info,
+            part_upload_requests=response.part_upload_requests,
+            encryption_data=encryption,
+            _access_token=access_token,
+            upo_v43=upo_v43,
+            offline_mode=offline_mode,
+            _encrypted_parts=_indexed_parts(encrypted_parts),
+        )
+
+    def resume_session(
+        self,
+        state: BatchSessionState,
+        *,
+        zip_bytes: bytes,
+        access_token: str | None = None,
+    ) -> AsyncBatchSessionHandle:
+        return AsyncBatchSessionHandle.from_state(
+            state,
+            sessions_client=self._sessions,
+            uploader=self._upload_helper,
+            access_token=access_token,
+            zip_bytes=zip_bytes,
+        )
+
+    async def open_upload_and_close(
+        self,
+        *,
+        form_code: FormCode,
+        zip_bytes: bytes,
+        public_certificate: str,
+        access_token: str,
+        offline_mode: bool | None = None,
+        upo_v43: bool = False,
+        parallelism: int = 1,
+    ) -> str:
+        _ = parallelism
+        session = await self.open_session(
+            form_code=form_code,
+            zip_bytes=zip_bytes,
+            public_certificate=public_certificate,
+            access_token=access_token,
+            offline_mode=offline_mode,
+            upo_v43=upo_v43,
+        )
+        await session.upload_parts()
+        await session.close(access_token=access_token)
+        return session.reference_number
 
 
 class ExportDownloadHelper:

--- a/src/ksef_client/services/workflows.py
+++ b/src/ksef_client/services/workflows.py
@@ -48,6 +48,12 @@ from .sessions import (
     OnlineSessionState,
     _indexed_parts,
 )
+from .sessions import (
+    _AsyncSessionsClient as _HandleAsyncSessionsClient,
+)
+from .sessions import (
+    _SessionsClient as _HandleSessionsClient,
+)
 from .xades import XadesKeyPair
 
 
@@ -576,7 +582,7 @@ class OnlineSessionWorkflow:
             upo_v43=upo_v43,
         )
         return OnlineSessionHandle(
-            _sessions=self._sessions,
+            _sessions=cast(_HandleSessionsClient, self._sessions),
             reference_number=response.reference_number,
             form_code=form_code,
             valid_until=response.valid_until,
@@ -593,7 +599,7 @@ class OnlineSessionWorkflow:
     ) -> OnlineSessionHandle:
         return OnlineSessionHandle.from_state(
             state,
-            sessions_client=self._sessions,
+            sessions_client=cast(_HandleSessionsClient, self._sessions),
             access_token=access_token,
         )
 
@@ -646,7 +652,7 @@ class AsyncOnlineSessionWorkflow:
             upo_v43=upo_v43,
         )
         return AsyncOnlineSessionHandle(
-            _sessions=self._sessions,
+            _sessions=cast(_HandleAsyncSessionsClient, self._sessions),
             reference_number=response.reference_number,
             form_code=form_code,
             valid_until=response.valid_until,
@@ -663,7 +669,7 @@ class AsyncOnlineSessionWorkflow:
     ) -> AsyncOnlineSessionHandle:
         return AsyncOnlineSessionHandle.from_state(
             state,
-            sessions_client=self._sessions,
+            sessions_client=cast(_HandleAsyncSessionsClient, self._sessions),
             access_token=access_token,
         )
 
@@ -724,7 +730,7 @@ class BatchSessionWorkflow:
             upo_v43=upo_v43,
         )
         return BatchSessionHandle(
-            _sessions=self._sessions,
+            _sessions=cast(_HandleSessionsClient, self._sessions),
             _uploader=self._upload_helper,
             reference_number=response.reference_number,
             form_code=form_code,
@@ -746,7 +752,7 @@ class BatchSessionWorkflow:
     ) -> BatchSessionHandle:
         return BatchSessionHandle.from_state(
             state,
-            sessions_client=self._sessions,
+            sessions_client=cast(_HandleSessionsClient, self._sessions),
             uploader=self._upload_helper,
             access_token=access_token,
             zip_bytes=zip_bytes,
@@ -808,7 +814,7 @@ class AsyncBatchSessionWorkflow:
             upo_v43=upo_v43,
         )
         return AsyncBatchSessionHandle(
-            _sessions=self._sessions,
+            _sessions=cast(_HandleAsyncSessionsClient, self._sessions),
             _uploader=self._upload_helper,
             reference_number=response.reference_number,
             form_code=form_code,
@@ -830,7 +836,7 @@ class AsyncBatchSessionWorkflow:
     ) -> AsyncBatchSessionHandle:
         return AsyncBatchSessionHandle.from_state(
             state,
-            sessions_client=self._sessions,
+            sessions_client=cast(_HandleAsyncSessionsClient, self._sessions),
             uploader=self._upload_helper,
             access_token=access_token,
             zip_bytes=zip_bytes,

--- a/tests/cli/smoke/test_cli_resume_recovery_flows.py
+++ b/tests/cli/smoke/test_cli_resume_recovery_flows.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ksef_client import models as m
+from ksef_client.cli import app
+from ksef_client.cli.exit_codes import ExitCode
+from ksef_client.cli.sdk import adapters, session_ops
+from ksef_client.cli.session_store import (
+    BatchSessionCheckpoint,
+    OnlineSessionCheckpoint,
+    load_checkpoint,
+)
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+
+class _FakeClient:
+    def __init__(self, *, sessions=None, security=None, http_client=None) -> None:
+        self.sessions = sessions
+        self.security = security
+        self.http_client = http_client
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        _ = (exc_type, exc, tb)
+
+
+class _Security:
+    def get_public_key_certificates(self):
+        return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+
+class _BatchSessionsApi:
+    def close_batch_session(self, reference_number, access_token=None):
+        _ = (reference_number, access_token)
+
+
+def _json_output(text: str) -> dict[str, Any]:
+    return json.loads(text.strip().splitlines()[-1])
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def _online_state(reference_number: str) -> OnlineSessionState:
+    return OnlineSessionState(
+        reference_number=reference_number,
+        form_code=_form_code(),
+        valid_until="2026-04-01T12:30:00Z",
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+
+
+def _batch_state(reference_number: str) -> BatchSessionState:
+    return BatchSessionState(
+        reference_number=reference_number,
+        form_code=_form_code(),
+        batch_file=m.BatchFileInfo.from_dict(
+            {
+                "fileSize": 10,
+                "fileHash": "hash",
+                "fileParts": [
+                    {"ordinalNumber": 1, "fileSize": 5, "fileHash": "hash-1"},
+                    {"ordinalNumber": 2, "fileSize": 5, "fileHash": "hash-2"},
+                ],
+            }
+        ),
+        part_upload_requests=[
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 1,
+                    "url": "https://upload/1",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            ),
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 2,
+                    "url": "https://upload/2",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            ),
+        ],
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+
+
+def test_cli_online_resume_uses_disk_checkpoint_after_logical_restart(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=object(),
+        ),
+    )
+
+    class _OpenHandle:
+        def __init__(self, state: OnlineSessionState) -> None:
+            self._state = state
+
+        def get_state(self) -> OnlineSessionState:
+            return self._state
+
+    class _OpenWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _OpenHandle(_online_state("SES-RESTART-ONLINE"))
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _OpenWorkflow)
+
+    invoice_path = tmp_path / "invoice.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    open_result = runner.invoke(app, ["session", "online", "open", "--id", "restart-online"])
+    assert open_result.exit_code == 0
+
+    resumed_refs: list[str] = []
+
+    class _ResumeHandle:
+        def __init__(self, state: OnlineSessionState) -> None:
+            self._state = state
+
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            resumed_refs.append(self._state.reference_number)
+            return {"referenceNumber": "INV-RESTART-1"}
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            resumed_refs.append(self._state.reference_number)
+
+    class _ResumeWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def resume_session(self, state, *, access_token=None):
+            _ = access_token
+            return _ResumeHandle(state)
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _ResumeWorkflow)
+
+    send_result = runner.invoke(
+        app,
+        ["session", "online", "send", "--id", "restart-online", "--invoice", str(invoice_path)],
+    )
+    assert send_result.exit_code == 0
+
+    close_result = runner.invoke(app, ["session", "online", "close", "--id", "restart-online"])
+    assert close_result.exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "restart-online")
+    assert isinstance(checkpoint, OnlineSessionCheckpoint)
+    assert checkpoint.last_invoice_ref == "INV-RESTART-1"
+    assert checkpoint.stage == "closed"
+    assert resumed_refs == ["SES-RESTART-ONLINE", "SES-RESTART-ONLINE"]
+
+
+def test_cli_batch_partial_upload_can_resume_after_logical_restart(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=_BatchSessionsApi(),
+            http_client=object(),
+        ),
+    )
+
+    class _OpenHandle:
+        def get_state(self) -> BatchSessionState:
+            return _batch_state("SES-RESTART-BATCH")
+
+    class _OpenWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _OpenHandle()
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _OpenWorkflow)
+
+    batch_dir = tmp_path / "batch"
+    batch_dir.mkdir()
+    (batch_dir / "1.xml").write_text("<a/>", encoding="utf-8")
+    (batch_dir / "2.xml").write_text("<b/>", encoding="utf-8")
+
+    open_result = runner.invoke(
+        app,
+        ["session", "batch", "open", "--id", "restart-batch", "--dir", str(batch_dir)],
+    )
+    assert open_result.exit_code == 0
+
+    class _FirstUploadHandle:
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = parallelism
+            if progress_callback is not None and 1 not in set(skip_ordinals or []):
+                progress_callback(1)
+
+    class _FirstUploadWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            _ = (state, zip_bytes, access_token)
+            return _FirstUploadHandle()
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _FirstUploadWorkflow)
+
+    first_upload = runner.invoke(
+        app,
+        ["session", "batch", "upload", "--id", "restart-batch", "--parallelism", "1"],
+    )
+    assert first_upload.exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "restart-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
+    assert checkpoint.uploaded_ordinals == [1]
+    assert checkpoint.stage == "uploaded"
+
+    seen_skip_ordinals: list[int] = []
+
+    class _SecondUploadHandle:
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = parallelism
+            seen_skip_ordinals[:] = sorted(skip_ordinals or [])
+            if progress_callback is not None and 2 not in set(skip_ordinals or []):
+                progress_callback(2)
+
+    class _SecondUploadWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            _ = (state, zip_bytes, access_token)
+            return _SecondUploadHandle()
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _SecondUploadWorkflow)
+
+    second_upload = runner.invoke(
+        app,
+        ["session", "batch", "upload", "--id", "restart-batch", "--parallelism", "1"],
+    )
+    assert second_upload.exit_code == 0
+
+    close_result = runner.invoke(app, ["session", "batch", "close", "--id", "restart-batch"])
+    assert close_result.exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "restart-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
+    assert checkpoint.stage == "closed"
+    assert checkpoint.uploaded_ordinals == [1, 2]
+    assert seen_skip_ordinals == [1]
+
+
+def test_cli_batch_resume_rejects_changed_payload_source(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=_BatchSessionsApi(),
+            http_client=object(),
+        ),
+    )
+
+    class _OpenHandle:
+        def get_state(self) -> BatchSessionState:
+            return _batch_state("SES-MISMATCH-BATCH")
+
+    class _OpenWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _OpenHandle()
+
+    class _UnexpectedResumeWorkflow(_OpenWorkflow):
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            raise AssertionError("payload mismatch should fail before resume_session")
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _OpenWorkflow)
+
+    batch_dir = tmp_path / "batch-mismatch"
+    batch_dir.mkdir()
+    invoice_path = batch_dir / "1.xml"
+    invoice_path.write_text("<a/>", encoding="utf-8")
+
+    open_result = runner.invoke(
+        app,
+        ["session", "batch", "open", "--id", "mismatch-batch", "--dir", str(batch_dir)],
+    )
+    assert open_result.exit_code == 0
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _UnexpectedResumeWorkflow)
+    invoice_path.write_text("<changed/>", encoding="utf-8")
+
+    upload_result = runner.invoke(
+        app,
+        ["--json", "session", "batch", "upload", "--id", "mismatch-batch", "--parallelism", "1"],
+    )
+
+    assert upload_result.exit_code == int(ExitCode.VALIDATION_ERROR)
+    payload = _json_output(upload_result.stdout)
+    assert payload["errors"][0]["code"] == ExitCode.VALIDATION_ERROR.name
+    assert "Batch payload source changed" in payload["errors"][0]["message"]
+
+
+def test_cli_online_resume_requires_stored_token_after_open(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=object(),
+        ),
+    )
+
+    class _OpenHandle:
+        def get_state(self) -> OnlineSessionState:
+            return _online_state("SES-TOKEN-ONLINE")
+
+    class _OpenWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _OpenHandle()
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _OpenWorkflow)
+
+    invoice_path = tmp_path / "invoice.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    open_result = runner.invoke(app, ["session", "online", "open", "--id", "token-online"])
+    assert open_result.exit_code == 0
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: None)
+
+    send_result = runner.invoke(
+        app,
+        [
+            "--json",
+            "session",
+            "online",
+            "send",
+            "--id",
+            "token-online",
+            "--invoice",
+            str(invoice_path),
+        ],
+    )
+
+    assert send_result.exit_code == int(ExitCode.AUTH_ERROR)
+    payload = _json_output(send_result.stdout)
+    assert payload["errors"][0]["code"] == ExitCode.AUTH_ERROR.name
+
+
+def test_cli_send_online_save_session_can_recover_via_session_commands(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=object(),
+        ),
+    )
+
+    class _FailingSendHandle:
+        session_reference_number = "SES-SEND-ONLINE"
+
+        def get_state(self) -> OnlineSessionState:
+            return _online_state("SES-SEND-ONLINE")
+
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            raise RuntimeError("transient send failure")
+
+        def close(self, *, access_token=None):
+            _ = access_token
+
+    class _FailingSendWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _FailingSendHandle()
+
+    monkeypatch.setattr(adapters, "OnlineSessionWorkflow", _FailingSendWorkflow)
+
+    invoice_path = tmp_path / "invoice-send.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    failed_send = runner.invoke(
+        app,
+        ["send", "online", "--invoice", str(invoice_path), "--save-session", "recover-online"],
+    )
+    assert failed_send.exit_code == int(ExitCode.CONFIG_ERROR)
+
+    checkpoint = load_checkpoint("demo", "recover-online")
+    assert isinstance(checkpoint, OnlineSessionCheckpoint)
+    assert checkpoint.stage == "opened"
+
+    class _RecoveredSendHandle:
+        def __init__(self, state: OnlineSessionState) -> None:
+            self._state = state
+
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            return {"referenceNumber": "INV-RECOVERED-ONLINE"}
+
+        def close(self, *, access_token=None):
+            _ = access_token
+
+    class _RecoveredWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def resume_session(self, state, *, access_token=None):
+            _ = access_token
+            return _RecoveredSendHandle(state)
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _RecoveredWorkflow)
+
+    resume_send = runner.invoke(
+        app,
+        ["session", "online", "send", "--id", "recover-online", "--invoice", str(invoice_path)],
+    )
+    assert resume_send.exit_code == 0
+
+    close_result = runner.invoke(app, ["session", "online", "close", "--id", "recover-online"])
+    assert close_result.exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "recover-online")
+    assert isinstance(checkpoint, OnlineSessionCheckpoint)
+    assert checkpoint.last_invoice_ref == "INV-RECOVERED-ONLINE"
+    assert checkpoint.stage == "closed"
+
+
+def test_cli_send_batch_save_session_can_recover_via_session_commands(
+    runner, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=_BatchSessionsApi(),
+            http_client=object(),
+        ),
+    )
+
+    class _FailingBatchHandle:
+        reference_number = "SES-SEND-BATCH"
+
+        def get_state(self) -> BatchSessionState:
+            return _batch_state("SES-SEND-BATCH")
+
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = (parallelism, skip_ordinals)
+            if progress_callback is not None:
+                progress_callback(1)
+            raise RuntimeError("transient upload failure")
+
+        def close(self, *, access_token=None):
+            _ = access_token
+
+    class _FailingBatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _FailingBatchHandle()
+
+    monkeypatch.setattr(adapters, "BatchSessionWorkflow", _FailingBatchWorkflow)
+
+    batch_dir = tmp_path / "batch-recover"
+    batch_dir.mkdir()
+    (batch_dir / "1.xml").write_text("<a/>", encoding="utf-8")
+    (batch_dir / "2.xml").write_text("<b/>", encoding="utf-8")
+
+    failed_send = runner.invoke(
+        app,
+        ["send", "batch", "--dir", str(batch_dir), "--save-session", "recover-batch"],
+    )
+    assert failed_send.exit_code == int(ExitCode.CONFIG_ERROR)
+
+    checkpoint = load_checkpoint("demo", "recover-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
+    assert checkpoint.stage == "uploading"
+    assert checkpoint.uploaded_ordinals == [1]
+
+    seen_skip_ordinals: list[int] = []
+
+    class _RecoveredBatchHandle:
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = parallelism
+            seen_skip_ordinals[:] = sorted(skip_ordinals or [])
+            if progress_callback is not None and 2 not in set(skip_ordinals or []):
+                progress_callback(2)
+
+    class _RecoveredBatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            _ = (state, zip_bytes, access_token)
+            return _RecoveredBatchHandle()
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _RecoveredBatchWorkflow)
+
+    resume_upload = runner.invoke(
+        app,
+        ["session", "batch", "upload", "--id", "recover-batch", "--parallelism", "1"],
+    )
+    assert resume_upload.exit_code == 0
+
+    close_result = runner.invoke(app, ["session", "batch", "close", "--id", "recover-batch"])
+    assert close_result.exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "recover-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
+    assert checkpoint.stage == "closed"
+    assert checkpoint.uploaded_ordinals == [1, 2]
+    assert seen_skip_ordinals == [1]

--- a/tests/cli/smoke/test_cli_session_resume_flow.py
+++ b/tests/cli/smoke/test_cli_session_resume_flow.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ksef_client import models as m
+from ksef_client.cli import app
+from ksef_client.cli.sdk import session_ops
+from ksef_client.cli.session_store import load_checkpoint
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+
+class _FakeClient:
+    def __init__(self, *, sessions=None, security=None, http_client=None) -> None:
+        self.sessions = sessions
+        self.security = security
+        self.http_client = http_client
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        _ = (exc_type, exc, tb)
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def test_cli_online_session_resume_flow(runner, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(session_ops.adapters, "get_tokens", lambda profile: ("acc", "ref"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _Handle:
+        def __init__(self, state: OnlineSessionState) -> None:
+            self._state = state
+
+        @property
+        def session_reference_number(self) -> str:
+            return self._state.reference_number
+
+        def get_state(self) -> OnlineSessionState:
+            return self._state
+
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            return {"referenceNumber": "INV-SMOKE-1"}
+
+        def close(self, *, access_token=None):
+            _ = access_token
+
+    class _Workflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _Handle(
+                OnlineSessionState(
+                    reference_number="SES-SMOKE-ONLINE",
+                    form_code=_form_code(),
+                    valid_until="2026-04-01T12:30:00Z",
+                    symmetric_key_base64="AQID",
+                    iv_base64="BAUG",
+                )
+            )
+
+        def resume_session(self, state, *, access_token=None):
+            _ = access_token
+            return _Handle(state)
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _Workflow)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=object(),
+        ),
+    )
+
+    invoice_path = tmp_path / "invoice.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    assert runner.invoke(app, ["session", "online", "open", "--id", "smoke-online"]).exit_code == 0
+    assert (
+        runner.invoke(
+            app,
+            ["session", "online", "send", "--id", "smoke-online", "--invoice", str(invoice_path)],
+        ).exit_code
+        == 0
+    )
+    assert runner.invoke(app, ["session", "online", "close", "--id", "smoke-online"]).exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "smoke-online")
+    assert checkpoint.kind == "online"
+    assert checkpoint.stage == "closed"
+
+
+def test_cli_batch_session_resume_flow(runner, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(session_ops.adapters, "get_tokens", lambda profile: ("acc", "ref"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _BatchSessionsApi:
+        def close_batch_session(self, reference_number, access_token=None):
+            _ = (reference_number, access_token)
+
+    class _BatchHandle:
+        def __init__(self, state: BatchSessionState) -> None:
+            self._state = state
+
+        @property
+        def reference_number(self) -> str:
+            return self._state.reference_number
+
+        def get_state(self) -> BatchSessionState:
+            return self._state
+
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = (parallelism, skip_ordinals)
+            if progress_callback is not None:
+                progress_callback(1)
+
+        def close(self, *, access_token=None):
+            _ = access_token
+
+    batch_state = BatchSessionState(
+        reference_number="SES-SMOKE-BATCH",
+        form_code=_form_code(),
+        batch_file=m.BatchFileInfo.from_dict(
+            {
+                "fileSize": 10,
+                "fileHash": "hash",
+                "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-1"}],
+            }
+        ),
+        part_upload_requests=[
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 1,
+                    "url": "https://upload/1",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            )
+        ],
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+
+    class _BatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _BatchHandle(batch_state)
+
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            _ = (zip_bytes, access_token)
+            return _BatchHandle(state)
+
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _BatchWorkflow)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=_BatchSessionsApi(),
+            http_client=object(),
+        ),
+    )
+
+    batch_dir = tmp_path / "batch"
+    batch_dir.mkdir()
+    (batch_dir / "1.xml").write_text("<a/>", encoding="utf-8")
+
+    assert (
+        runner.invoke(
+            app,
+            ["session", "batch", "open", "--id", "smoke-batch", "--dir", str(batch_dir)],
+        ).exit_code
+        == 0
+    )
+    assert (
+        runner.invoke(
+            app,
+            ["session", "batch", "upload", "--id", "smoke-batch", "--parallelism", "1"],
+        ).exit_code
+        == 0
+    )
+    assert runner.invoke(app, ["session", "batch", "close", "--id", "smoke-batch"]).exit_code == 0
+
+    checkpoint = load_checkpoint("demo", "smoke-batch")
+    assert checkpoint.kind == "batch"
+    assert checkpoint.stage == "closed"
+    assert checkpoint.uploaded_ordinals == [1]

--- a/tests/cli/smoke/test_cli_session_resume_flow.py
+++ b/tests/cli/smoke/test_cli_session_resume_flow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ksef_client import models as m
 from ksef_client.cli import app
 from ksef_client.cli.sdk import session_ops
-from ksef_client.cli.session_store import load_checkpoint
+from ksef_client.cli.session_store import BatchSessionCheckpoint, load_checkpoint
 from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
 
 
@@ -197,6 +197,7 @@ def test_cli_batch_session_resume_flow(runner, monkeypatch, tmp_path: Path) -> N
     assert runner.invoke(app, ["session", "batch", "close", "--id", "smoke-batch"]).exit_code == 0
 
     checkpoint = load_checkpoint("demo", "smoke-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
     assert checkpoint.kind == "batch"
     assert checkpoint.stage == "closed"
     assert checkpoint.uploaded_ordinals == [1]

--- a/tests/cli/unit/test_command_error_rendering.py
+++ b/tests/cli/unit/test_command_error_rendering.py
@@ -15,6 +15,7 @@ from ksef_client.cli.commands import (
     invoice_cmd,
     profile_cmd,
     send_cmd,
+    session_cmd,
     upo_cmd,
 )
 from ksef_client.cli.context import CliContext
@@ -35,6 +36,7 @@ def _ctx() -> typer.Context:
         (auth_cmd, "auth.test"),
         (invoice_cmd, "invoice.test"),
         (send_cmd, "send.test"),
+        (session_cmd, "session.test"),
         (upo_cmd, "upo.test"),
         (export_cmd, "export.test"),
         (health_cmd, "health.test"),
@@ -52,6 +54,7 @@ def test_render_error_cli_error(module, command) -> None:
         (auth_cmd, "auth.test"),
         (invoice_cmd, "invoice.test"),
         (send_cmd, "send.test"),
+        (session_cmd, "session.test"),
         (upo_cmd, "upo.test"),
         (export_cmd, "export.test"),
         (health_cmd, "health.test"),
@@ -81,7 +84,7 @@ def test_auth_render_error_api_and_http() -> None:
 
 @pytest.mark.parametrize(
     "module",
-    [invoice_cmd, send_cmd, upo_cmd, export_cmd, health_cmd],
+    [invoice_cmd, send_cmd, session_cmd, upo_cmd, export_cmd, health_cmd],
 )
 def test_render_error_api_http_combined(module) -> None:
     with pytest.raises(typer.Exit) as api_exc:
@@ -95,7 +98,17 @@ def test_render_error_api_http_combined(module) -> None:
 
 @pytest.mark.parametrize(
     "module",
-    [auth_cmd, invoice_cmd, send_cmd, upo_cmd, export_cmd, health_cmd, init_cmd, profile_cmd],
+    [
+        auth_cmd,
+        invoice_cmd,
+        send_cmd,
+        session_cmd,
+        upo_cmd,
+        export_cmd,
+        health_cmd,
+        init_cmd,
+        profile_cmd,
+    ],
 )
 def test_render_error_unexpected(module) -> None:
     with pytest.raises(typer.Exit) as exc:

--- a/tests/cli/unit/test_send_resume_adapters.py
+++ b/tests/cli/unit/test_send_resume_adapters.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from ksef_client import models as m
 from ksef_client.cli.sdk import adapters
-from ksef_client.cli.session_store import load_checkpoint
+from ksef_client.cli.session_store import BatchSessionCheckpoint, load_checkpoint
 from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
 
 
@@ -232,8 +235,354 @@ def test_send_batch_invoices_can_persist_session_checkpoint(monkeypatch, tmp_pat
 
     assert result["session_id"] == "resume-batch"
     checkpoint = load_checkpoint("demo", "resume-batch")
+    assert isinstance(checkpoint, BatchSessionCheckpoint)
     assert checkpoint.kind == "batch"
     assert checkpoint.stage == "closed"
     assert checkpoint.uploaded_ordinals == [1, 2]
     assert checkpoint.to_dict().get("access_token") is None
+    assert workflow_holder["workflow"].handle.closed == 1
+
+
+def test_send_online_invoice_closes_session_when_checkpoint_save_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _SessionHandle:
+        session_reference_number = "SES-ONLINE-1"
+        encryption_data = SimpleNamespace(key=b"k", iv=b"i")
+
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def get_state(self):
+            return OnlineSessionState(
+                reference_number="SES-ONLINE-1",
+                form_code=_form_code(),
+                valid_until="2026-04-01T12:30:00Z",
+                symmetric_key_base64="AQID",
+                iv_base64="BAUG",
+            )
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            self.closed += 1
+
+    class _OnlineWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+            self.handle = _SessionHandle()
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return self.handle
+
+    workflow_holder: dict[str, _OnlineWorkflow] = {}
+
+    def _workflow_factory(sessions):
+        workflow = _OnlineWorkflow(sessions)
+        workflow_holder["workflow"] = workflow
+        return workflow
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(adapters, "OnlineSessionWorkflow", _workflow_factory)
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=SimpleNamespace(),
+        ),
+    )
+    monkeypatch.setattr(
+        adapters,
+        "save_checkpoint",
+        lambda checkpoint, overwrite=False: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    invoice_path = tmp_path / "invoice.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        adapters.send_online_invoice(
+            profile="demo",
+            base_url="https://example.invalid",
+            invoice=str(invoice_path),
+            system_code="FA (3)",
+            schema_version="1-0E",
+            form_value="FA",
+            upo_v43=False,
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo=None,
+            save_session="resume-online",
+        )
+
+    assert workflow_holder["workflow"].handle.closed == 1
+
+
+def test_send_batch_invoices_handles_progress_checkpoint_edge_cases(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _BatchHandle:
+        reference_number = "SES-BATCH-1"
+
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def get_state(self):
+            return BatchSessionState(
+                reference_number="SES-BATCH-1",
+                form_code=_form_code(),
+                batch_file=m.BatchFileInfo.from_dict(
+                    {
+                        "fileSize": 10,
+                        "fileHash": "hash",
+                        "fileParts": [
+                            {"ordinalNumber": 1, "fileSize": 5, "fileHash": "hash-1"},
+                            {"ordinalNumber": 2, "fileSize": 5, "fileHash": "hash-2"},
+                        ],
+                    }
+                ),
+                part_upload_requests=[
+                    m.PartUploadRequest.from_dict(
+                        {
+                            "ordinalNumber": 1,
+                            "url": "https://upload/1",
+                            "method": "PUT",
+                            "headers": {},
+                        }
+                    ),
+                    m.PartUploadRequest.from_dict(
+                        {
+                            "ordinalNumber": 2,
+                            "url": "https://upload/2",
+                            "method": "PUT",
+                            "headers": {},
+                        }
+                    ),
+                ],
+                symmetric_key_base64="AQID",
+                iv_base64="BAUG",
+            )
+
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = (parallelism, skip_ordinals)
+            if progress_callback is not None:
+                progress_callback(1)
+                progress_callback(2)
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            self.closed += 1
+
+    class _BatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+            self.handle = _BatchHandle()
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return self.handle
+
+    workflow_holder: dict[str, _BatchWorkflow] = {}
+    saved: dict[str, BatchSessionCheckpoint] = {}
+
+    def _workflow_factory(sessions, http_client):
+        workflow = _BatchWorkflow(sessions, http_client)
+        workflow_holder["workflow"] = workflow
+        return workflow
+
+    def _save_checkpoint(checkpoint, overwrite=False):
+        _ = overwrite
+        saved["checkpoint"] = checkpoint
+
+    def _update_checkpoint(checkpoint, **changes):
+        base = saved["checkpoint"] if checkpoint is None else checkpoint
+        if changes.get("stage") == "uploading" and changes.get("uploaded_ordinals") == [1]:
+            return None
+        updated = replace(base, **changes)
+        saved["checkpoint"] = updated
+        return updated
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(adapters, "BatchSessionWorkflow", _workflow_factory)
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=SimpleNamespace(),
+            http_client=SimpleNamespace(),
+        ),
+    )
+    monkeypatch.setattr(adapters, "_load_batch_zip", lambda path: b"zip!")
+    monkeypatch.setattr(
+        adapters,
+        "_build_batch_payload_source",
+        lambda *, zip_path, directory, zip_bytes: adapters.BatchPayloadSource(
+            kind="zip",
+            path=str(zip_path),
+            source_sha256_base64="hash",
+            source_size=len(zip_bytes),
+        ),
+    )
+    monkeypatch.setattr(adapters, "save_checkpoint", _save_checkpoint)
+    monkeypatch.setattr(adapters, "update_checkpoint", _update_checkpoint)
+    monkeypatch.setattr(
+        adapters,
+        "_wait_for_session_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Accepted"}},
+    )
+    monkeypatch.setattr(adapters, "_extract_status_fields", lambda payload: (200, "Accepted", []))
+    monkeypatch.setattr(adapters, "_extract_upo_reference", lambda payload: "UPO-1")
+
+    batch_zip = tmp_path / "batch.zip"
+    batch_zip.write_bytes(b"zip!")
+
+    result = adapters.send_batch_invoices(
+        profile="demo",
+        base_url="https://example.invalid",
+        zip_path=str(batch_zip),
+        directory=None,
+        system_code="FA (3)",
+        schema_version="1-0E",
+        form_value="FA",
+        parallelism=2,
+        upo_v43=False,
+        wait_status=True,
+        wait_upo=False,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+        save_session="resume-batch",
+    )
+
+    assert result["status_code"] == 200
+    assert saved["checkpoint"].last_upo_ref == "UPO-1"
+    assert workflow_holder["workflow"].handle.closed == 1
+
+
+def test_send_batch_invoices_closes_session_when_checkpoint_save_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _BatchHandle:
+        reference_number = "SES-BATCH-1"
+
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def get_state(self):
+            return BatchSessionState(
+                reference_number="SES-BATCH-1",
+                form_code=_form_code(),
+                batch_file=m.BatchFileInfo.from_dict(
+                    {
+                        "fileSize": 10,
+                        "fileHash": "hash",
+                        "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-1"}],
+                    }
+                ),
+                part_upload_requests=[
+                    m.PartUploadRequest.from_dict(
+                        {
+                            "ordinalNumber": 1,
+                            "url": "https://upload/1",
+                            "method": "PUT",
+                            "headers": {},
+                        }
+                    )
+                ],
+                symmetric_key_base64="AQID",
+                iv_base64="BAUG",
+            )
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            self.closed += 1
+
+    class _BatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+            self.handle = _BatchHandle()
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return self.handle
+
+    workflow_holder: dict[str, _BatchWorkflow] = {}
+
+    def _workflow_factory(sessions, http_client):
+        workflow = _BatchWorkflow(sessions, http_client)
+        workflow_holder["workflow"] = workflow
+        return workflow
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(adapters, "BatchSessionWorkflow", _workflow_factory)
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=SimpleNamespace(),
+            http_client=SimpleNamespace(),
+        ),
+    )
+    monkeypatch.setattr(
+        adapters,
+        "_build_batch_payload_source",
+        lambda *, zip_path, directory, zip_bytes: adapters.BatchPayloadSource(
+            kind="zip",
+            path=str(zip_path),
+            source_sha256_base64="hash",
+            source_size=len(zip_bytes),
+        ),
+    )
+    monkeypatch.setattr(adapters, "_load_batch_zip", lambda path: b"zip!")
+    monkeypatch.setattr(
+        adapters,
+        "save_checkpoint",
+        lambda checkpoint, overwrite=False: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    batch_zip = tmp_path / "batch.zip"
+    batch_zip.write_bytes(b"zip!")
+
+    with pytest.raises(RuntimeError):
+        adapters.send_batch_invoices(
+            profile="demo",
+            base_url="https://example.invalid",
+            zip_path=str(batch_zip),
+            directory=None,
+            system_code="FA (3)",
+            schema_version="1-0E",
+            form_value="FA",
+            parallelism=1,
+            upo_v43=False,
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo=None,
+            save_session="resume-batch",
+        )
+
     assert workflow_holder["workflow"].handle.closed == 1

--- a/tests/cli/unit/test_send_resume_adapters.py
+++ b/tests/cli/unit/test_send_resume_adapters.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from ksef_client import models as m
+from ksef_client.cli.sdk import adapters
+from ksef_client.cli.session_store import load_checkpoint
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+
+class _FakeClient:
+    def __init__(self, *, security=None, sessions=None, http_client=None) -> None:
+        self.security = security
+        self.sessions = sessions
+        self.http_client = http_client
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        _ = (exc_type, exc, tb)
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def test_send_online_invoice_can_persist_session_checkpoint(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _SessionHandle:
+        session_reference_number = "SES-ONLINE-1"
+        encryption_data = SimpleNamespace(key=b"k", iv=b"i")
+
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def get_state(self):
+            return OnlineSessionState(
+                reference_number="SES-ONLINE-1",
+                form_code=_form_code(),
+                valid_until="2026-04-01T12:30:00Z",
+                symmetric_key_base64="AQID",
+                iv_base64="BAUG",
+                upo_v43=True,
+            )
+
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            return {"referenceNumber": "INV-ONLINE-1"}
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            self.closed += 1
+
+    class _OnlineWorkflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+            self.handle = _SessionHandle()
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return self.handle
+
+        def close_session(self, reference_number, access_token):
+            _ = (reference_number, access_token)
+            self.handle.close(access_token=access_token)
+
+    workflow_holder: dict[str, _OnlineWorkflow] = {}
+
+    def _workflow_factory(sessions):
+        workflow = _OnlineWorkflow(sessions)
+        workflow_holder["workflow"] = workflow
+        return workflow
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(adapters, "OnlineSessionWorkflow", _workflow_factory)
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=SimpleNamespace(),
+        ),
+    )
+
+    invoice_path = tmp_path / "invoice.xml"
+    invoice_path.write_text("<faktura/>", encoding="utf-8")
+
+    result = adapters.send_online_invoice(
+        profile="demo",
+        base_url="https://example.invalid",
+        invoice=str(invoice_path),
+        system_code="FA (3)",
+        schema_version="1-0E",
+        form_value="FA",
+        upo_v43=True,
+        wait_status=False,
+        wait_upo=False,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+        save_session="resume-online",
+    )
+
+    assert result["session_id"] == "resume-online"
+    checkpoint = load_checkpoint("demo", "resume-online")
+    assert checkpoint.kind == "online"
+    assert checkpoint.stage == "closed"
+    assert checkpoint.to_dict().get("access_token") is None
+    assert workflow_holder["workflow"].handle.closed == 1
+
+
+def test_send_batch_invoices_can_persist_session_checkpoint(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    class _Security:
+        def get_public_key_certificates(self):
+            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+
+    class _BatchHandle:
+        reference_number = "SES-BATCH-1"
+
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def get_state(self):
+            return BatchSessionState(
+                reference_number="SES-BATCH-1",
+                form_code=_form_code(),
+                batch_file=m.BatchFileInfo.from_dict(
+                    {
+                        "fileSize": 10,
+                        "fileHash": "hash",
+                        "fileParts": [
+                            {"ordinalNumber": 1, "fileSize": 5, "fileHash": "hash-1"},
+                            {"ordinalNumber": 2, "fileSize": 5, "fileHash": "hash-2"},
+                        ],
+                    }
+                ),
+                part_upload_requests=[
+                    m.PartUploadRequest.from_dict(
+                        {
+                            "ordinalNumber": 1,
+                            "url": "https://upload/1",
+                            "method": "PUT",
+                            "headers": {},
+                        }
+                    ),
+                    m.PartUploadRequest.from_dict(
+                        {
+                            "ordinalNumber": 2,
+                            "url": "https://upload/2",
+                            "method": "PUT",
+                            "headers": {},
+                        }
+                    ),
+                ],
+                symmetric_key_base64="AQID",
+                iv_base64="BAUG",
+            )
+
+        def upload_parts(self, *, parallelism=1, skip_ordinals=None, progress_callback=None):
+            _ = (parallelism, skip_ordinals)
+            if progress_callback:
+                progress_callback(1)
+                progress_callback(2)
+
+        def close(self, *, access_token=None):
+            _ = access_token
+            self.closed += 1
+
+    class _BatchWorkflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+            self.handle = _BatchHandle()
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return self.handle
+
+        def open_upload_and_close(self, **kwargs):
+            _ = kwargs
+            raise AssertionError("save_session path should not call open_upload_and_close")
+
+    workflow_holder: dict[str, _BatchWorkflow] = {}
+
+    def _workflow_factory(sessions, http_client):
+        workflow = _BatchWorkflow(sessions, http_client)
+        workflow_holder["workflow"] = workflow
+        return workflow
+
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+    monkeypatch.setattr(adapters, "BatchSessionWorkflow", _workflow_factory)
+    monkeypatch.setattr(
+        adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=_Security(),
+            sessions=SimpleNamespace(),
+            http_client=SimpleNamespace(),
+        ),
+    )
+
+    batch_dir = tmp_path / "batch"
+    batch_dir.mkdir()
+    (batch_dir / "1.xml").write_text("<a/>", encoding="utf-8")
+    (batch_dir / "2.xml").write_text("<b/>", encoding="utf-8")
+
+    result = adapters.send_batch_invoices(
+        profile="demo",
+        base_url="https://example.invalid",
+        zip_path=None,
+        directory=str(batch_dir),
+        system_code="FA (3)",
+        schema_version="1-0E",
+        form_value="FA",
+        parallelism=2,
+        upo_v43=False,
+        wait_status=False,
+        wait_upo=False,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+        save_session="resume-batch",
+    )
+
+    assert result["session_id"] == "resume-batch"
+    checkpoint = load_checkpoint("demo", "resume-batch")
+    assert checkpoint.kind == "batch"
+    assert checkpoint.stage == "closed"
+    assert checkpoint.uploaded_ordinals == [1, 2]
+    assert checkpoint.to_dict().get("access_token") is None
+    assert workflow_holder["workflow"].handle.closed == 1

--- a/tests/cli/unit/test_session_commands.py
+++ b/tests/cli/unit/test_session_commands.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+
+from ksef_client.cli import app
+from ksef_client.cli.commands import session_cmd
+
+
+def _payload(stdout: str) -> dict:
+    return json.loads(stdout.strip())
+
+
+def test_session_list_command_uses_selected_profile(runner, monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    def _fake_list_saved_sessions(*, profile: str):
+        seen["profile"] = profile
+        return {"count": 1, "items": [{"id": "demo"}]}
+
+    monkeypatch.setattr(session_cmd, "list_saved_sessions", _fake_list_saved_sessions)
+
+    result = runner.invoke(app, ["--json", "session", "list"])
+
+    assert result.exit_code == 0
+    assert seen["profile"] == "demo"
+    assert _payload(result.stdout)["data"]["count"] == 1
+
+
+def test_session_online_open_command_resolves_base_url(runner, monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_open_online_session(**kwargs):
+        seen.update(kwargs)
+        return {"id": kwargs["session_id"], "session_ref": "SES-1"}
+
+    monkeypatch.setattr(session_cmd, "open_online_session", _fake_open_online_session)
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "session",
+            "online",
+            "open",
+            "--id",
+            "resume-1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert seen["profile"] == "demo"
+    assert seen["base_url"] == "https://api-demo.ksef.mf.gov.pl"
+    assert seen["session_id"] == "resume-1"
+    assert _payload(result.stdout)["command"] == "session.online.open"
+
+
+def test_session_status_command_passes_invoice_ref(runner, monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_get_saved_session_status(**kwargs):
+        seen.update(kwargs)
+        return {"session_ref": "SES-1", "status_code": 200}
+
+    monkeypatch.setattr(session_cmd, "get_saved_session_status", _fake_get_saved_session_status)
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "session",
+            "status",
+            "--id",
+            "resume-1",
+            "--invoice-ref",
+            "INV-1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert seen["session_id"] == "resume-1"
+    assert seen["invoice_ref"] == "INV-1"
+    assert _payload(result.stdout)["data"]["status_code"] == 200
+
+
+def test_session_batch_close_command_forwards_wait_options(runner, monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_close_batch_session(**kwargs):
+        seen.update(kwargs)
+        return {"id": kwargs["session_id"], "stage": "closed"}
+
+    monkeypatch.setattr(session_cmd, "close_batch_session", _fake_close_batch_session)
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "session",
+            "batch",
+            "close",
+            "--id",
+            "batch-1",
+            "--wait-status",
+            "--wait-upo",
+            "--poll-interval",
+            "0.5",
+            "--max-attempts",
+            "5",
+            "--save-upo",
+            "upo.xml",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert seen["session_id"] == "batch-1"
+    assert seen["wait_status"] is True
+    assert seen["wait_upo"] is True
+    assert seen["save_upo"] == "upo.xml"
+    assert _payload(result.stdout)["command"] == "session.batch.close"

--- a/tests/cli/unit/test_session_commands.py
+++ b/tests/cli/unit/test_session_commands.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from ksef_client.cli import app
 from ksef_client.cli.commands import session_cmd
+from ksef_client.cli.errors import CliError
+from ksef_client.cli.exit_codes import ExitCode
 
 
 def _payload(stdout: str) -> dict:
@@ -82,6 +86,40 @@ def test_session_status_command_passes_invoice_ref(runner, monkeypatch) -> None:
     assert _payload(result.stdout)["data"]["status_code"] == 200
 
 
+@pytest.mark.parametrize(
+    ("attribute_name", "argv", "command"),
+    [
+        ("show_saved_session", ["--json", "session", "show", "--id", "resume-1"], "session.show"),
+        (
+            "export_saved_session",
+            ["--json", "session", "export", "--id", "resume-1", "--out", "out.json"],
+            "session.export",
+        ),
+        (
+            "import_saved_session",
+            ["--json", "session", "import", "--in", "resume.json"],
+            "session.import",
+        ),
+        ("drop_saved_session", ["--json", "session", "drop", "--id", "resume-1"], "session.drop"),
+    ],
+)
+def test_session_commands_render_success_for_general_actions(
+    runner, monkeypatch, attribute_name, argv, command
+) -> None:
+    monkeypatch.setattr(
+        session_cmd,
+        attribute_name,
+        lambda **kwargs: {"id": kwargs.get("session_id", "resume-1"), "ok": True},
+    )
+
+    result = runner.invoke(app, argv)
+
+    assert result.exit_code == 0
+    payload = _payload(result.stdout)
+    assert payload["command"] == command
+    assert payload["data"]["ok"] is True
+
+
 def test_session_batch_close_command_forwards_wait_options(runner, monkeypatch) -> None:
     seen: dict[str, object] = {}
 
@@ -117,3 +155,82 @@ def test_session_batch_close_command_forwards_wait_options(runner, monkeypatch) 
     assert seen["wait_upo"] is True
     assert seen["save_upo"] == "upo.xml"
     assert _payload(result.stdout)["command"] == "session.batch.close"
+
+
+@pytest.mark.parametrize(
+    ("attribute_name", "argv", "command"),
+    [
+        ("list_saved_sessions", ["--json", "session", "list"], "session.list"),
+        ("show_saved_session", ["--json", "session", "show", "--id", "resume-1"], "session.show"),
+        (
+            "get_saved_session_status",
+            ["--json", "session", "status", "--id", "resume-1"],
+            "session.status",
+        ),
+        (
+            "export_saved_session",
+            ["--json", "session", "export", "--id", "resume-1", "--out", "out.json"],
+            "session.export",
+        ),
+        (
+            "import_saved_session",
+            ["--json", "session", "import", "--in", "resume.json"],
+            "session.import",
+        ),
+        ("drop_saved_session", ["--json", "session", "drop", "--id", "resume-1"], "session.drop"),
+        (
+            "open_online_session",
+            ["--json", "session", "online", "open", "--id", "resume-1"],
+            "session.online.open",
+        ),
+        (
+            "send_online_session_invoice",
+            [
+                "--json",
+                "session",
+                "online",
+                "send",
+                "--id",
+                "resume-1",
+                "--invoice",
+                "invoice.xml",
+            ],
+            "session.online.send",
+        ),
+        (
+            "close_online_session",
+            ["--json", "session", "online", "close", "--id", "resume-1"],
+            "session.online.close",
+        ),
+        (
+            "open_batch_session",
+            ["--json", "session", "batch", "open", "--id", "resume-1", "--zip", "batch.zip"],
+            "session.batch.open",
+        ),
+        (
+            "upload_batch_session",
+            ["--json", "session", "batch", "upload", "--id", "resume-1"],
+            "session.batch.upload",
+        ),
+        (
+            "close_batch_session",
+            ["--json", "session", "batch", "close", "--id", "resume-1"],
+            "session.batch.close",
+        ),
+    ],
+)
+def test_session_commands_render_cli_errors(
+    runner, monkeypatch, attribute_name, argv, command
+) -> None:
+    def _boom(**kwargs):
+        _ = kwargs
+        raise CliError("broken", ExitCode.VALIDATION_ERROR, "fix-it")
+
+    monkeypatch.setattr(session_cmd, attribute_name, _boom)
+
+    result = runner.invoke(app, argv)
+
+    assert result.exit_code == int(ExitCode.VALIDATION_ERROR)
+    payload = _payload(result.stdout)
+    assert payload["command"] == command
+    assert payload["errors"][0]["code"] == ExitCode.VALIDATION_ERROR.name

--- a/tests/cli/unit/test_session_ops.py
+++ b/tests/cli/unit/test_session_ops.py
@@ -1,0 +1,762 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from ksef_client import models as m
+from ksef_client.cli.errors import CliError
+from ksef_client.cli.exit_codes import ExitCode
+from ksef_client.cli.sdk import session_ops
+from ksef_client.cli.session_store import (
+    BatchPayloadSource,
+    BatchSessionCheckpoint,
+    OnlineSessionCheckpoint,
+)
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def _online_checkpoint() -> OnlineSessionCheckpoint:
+    return OnlineSessionCheckpoint(
+        id="resume-online",
+        profile="demo",
+        base_url="https://api-demo.ksef.mf.gov.pl",
+        stage="opened",
+        session_state=OnlineSessionState(
+            reference_number="SES-ONLINE-1",
+            form_code=_form_code(),
+            valid_until="2026-04-01T12:30:00Z",
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+        ),
+    )
+
+
+def _batch_checkpoint() -> BatchSessionCheckpoint:
+    metadata = session_ops.get_file_metadata(b"zip!")
+    return BatchSessionCheckpoint(
+        id="resume-batch",
+        profile="demo",
+        base_url="https://api-demo.ksef.mf.gov.pl",
+        stage="opened",
+        session_state=BatchSessionState(
+            reference_number="SES-BATCH-1",
+            form_code=_form_code(),
+            batch_file=m.BatchFileInfo.from_dict(
+                {
+                    "fileSize": 4,
+                    "fileHash": "hash",
+                    "fileParts": [{"ordinalNumber": 1, "fileSize": 4, "fileHash": "hash-1"}],
+                }
+            ),
+            part_upload_requests=[
+                m.PartUploadRequest.from_dict(
+                    {
+                        "ordinalNumber": 1,
+                        "url": "https://upload/1",
+                        "method": "PUT",
+                        "headers": {},
+                    }
+                )
+            ],
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+        ),
+        payload_source=BatchPayloadSource(
+            kind="zip",
+            path="C:/tmp/invoices.zip",
+            source_sha256_base64=metadata.sha256_base64,
+            source_size=metadata.file_size,
+        ),
+    )
+
+
+class _FakeClient:
+    def __init__(self, *, sessions=None, security=None, http_client=None) -> None:
+        self.sessions = sessions
+        self.security = security
+        self.http_client = http_client
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        _ = (exc_type, exc, tb)
+
+
+def test_build_batch_payload_source_and_load_source_bytes(monkeypatch, tmp_path: Path) -> None:
+    with pytest.raises(CliError) as exc:
+        session_ops._build_batch_payload_source(zip_path=None, directory=None)
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+
+    zip_path = tmp_path / "payload.zip"
+    zip_path.write_bytes(b"zip!")
+    monkeypatch.setattr(
+        session_ops.adapters, "_load_batch_zip", lambda path: Path(path).read_bytes()
+    )
+    zip_bytes, payload_source = session_ops._build_batch_payload_source(
+        zip_path=str(zip_path),
+        directory=None,
+    )
+    assert zip_bytes == b"zip!"
+    assert payload_source.kind == "zip"
+
+    loaded = session_ops._load_batch_source_bytes(payload_source)
+    assert loaded == b"zip!"
+
+    with pytest.raises(CliError) as mismatch_exc:
+        session_ops._load_batch_source_bytes(
+            replace(
+                payload_source,
+                source_sha256_base64="different",
+            )
+        )
+    assert mismatch_exc.value.code == ExitCode.VALIDATION_ERROR
+
+
+def test_session_ops_require_checkpoint_type_and_simple_commands(monkeypatch) -> None:
+    batch_checkpoint = _batch_checkpoint()
+    online_checkpoint = _online_checkpoint()
+
+    monkeypatch.setattr(
+        session_ops, "load_checkpoint", lambda profile, session_id: batch_checkpoint
+    )
+    with pytest.raises(CliError) as online_exc:
+        session_ops._require_online_checkpoint("demo", "resume-batch")
+    assert online_exc.value.code == ExitCode.VALIDATION_ERROR
+
+    monkeypatch.setattr(
+        session_ops, "load_checkpoint", lambda profile, session_id: online_checkpoint
+    )
+    with pytest.raises(CliError) as batch_exc:
+        session_ops._require_batch_checkpoint("demo", "resume-online")
+    assert batch_exc.value.code == ExitCode.VALIDATION_ERROR
+
+    monkeypatch.setattr(
+        session_ops, "list_checkpoints", lambda profile: [online_checkpoint, batch_checkpoint]
+    )
+    listed = session_ops.list_saved_sessions(profile="demo")
+    assert listed["count"] == 2
+
+    monkeypatch.setattr(
+        session_ops, "load_checkpoint", lambda profile, session_id: batch_checkpoint
+    )
+    shown = session_ops.show_saved_session(profile="demo", session_id="resume-batch")
+    assert shown["payload_source"]["kind"] == "zip"
+
+    monkeypatch.setattr(
+        session_ops,
+        "export_checkpoint",
+        lambda profile, session_id, out: out / "saved.json",
+    )
+    exported = session_ops.export_saved_session(
+        profile="demo",
+        session_id="resume-online",
+        out="C:/tmp/export",
+    )
+    assert exported["path"].endswith("saved.json")
+
+    monkeypatch.setattr(
+        session_ops,
+        "import_checkpoint",
+        lambda profile, source_path, session_id=None: online_checkpoint,
+    )
+    imported = session_ops.import_saved_session(
+        profile="demo",
+        source_path="resume.json",
+        session_id="resume-online",
+    )
+    assert imported["id"] == "resume-online"
+
+    deleted: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        session_ops,
+        "delete_checkpoint",
+        lambda profile, session_id: deleted.append((profile, session_id)),
+    )
+    dropped = session_ops.drop_saved_session(profile="demo", session_id="resume-online")
+    assert dropped["deleted"] is True
+    assert deleted == [("demo", "resume-online")]
+
+    monkeypatch.setattr(
+        session_ops, "load_checkpoint", lambda profile, session_id: online_checkpoint
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "get_send_status",
+        lambda **kwargs: {"session_ref": kwargs["session_ref"], "status_code": 200},
+    )
+    status = session_ops.get_saved_session_status(
+        profile="demo",
+        session_id="resume-online",
+        invoice_ref="INV-1",
+    )
+    assert status["status_code"] == 200
+    assert status["id"] == "resume-online"
+
+
+def test_open_online_session_closes_handle_when_save_fails(monkeypatch) -> None:
+    closed: list[str | None] = []
+
+    class _Handle:
+        def get_state(self) -> OnlineSessionState:
+            return _online_checkpoint().session_state
+
+        def close(self, *, access_token=None) -> None:
+            closed.append(access_token)
+
+    class _Workflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _Handle()
+
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    monkeypatch.setattr(session_ops.adapters, "_build_form_code", lambda *args: _form_code())
+    monkeypatch.setattr(session_ops.adapters, "_select_certificate", lambda certs, usage: "CERT")
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _Workflow)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=SimpleNamespace(
+                get_public_key_certificates=lambda: [{"usage": ["SymmetricKeyEncryption"]}]
+            ),
+            sessions=object(),
+        ),
+    )
+    monkeypatch.setattr(
+        session_ops,
+        "save_checkpoint",
+        lambda checkpoint, overwrite=False: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError):
+        session_ops.open_online_session(
+            profile="demo",
+            base_url="https://example.invalid",
+            session_id="resume-online",
+            system_code="FA (3)",
+            schema_version="1-0E",
+            form_value="FA",
+            upo_v43=True,
+        )
+    assert closed == ["token"]
+
+
+def test_send_online_session_invoice_validates_and_waits(monkeypatch, tmp_path: Path) -> None:
+    checkpoint = _online_checkpoint()
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+
+    with pytest.raises(CliError) as exc:
+        session_ops.send_online_session_invoice(
+            profile="demo",
+            session_id="resume-online",
+            invoice="invoice.xml",
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo="upo.xml",
+        )
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+
+    class _Handle:
+        def send_invoice(self, invoice_xml: bytes, *, access_token=None):
+            _ = (invoice_xml, access_token)
+            return {}
+
+    class _WorkflowNoRef:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def resume_session(self, state, *, access_token=None):
+            _ = (state, access_token)
+            return _Handle()
+
+    monkeypatch.setattr(session_ops.adapters, "_load_invoice_xml", lambda invoice: b"<invoice/>")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(sessions=object()),
+    )
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _WorkflowNoRef)
+    monkeypatch.setattr(session_ops.adapters, "_extract_reference_number", lambda payload: "")
+
+    with pytest.raises(CliError) as no_ref_exc:
+        session_ops.send_online_session_invoice(
+            profile="demo",
+            session_id="resume-online",
+            invoice="invoice.xml",
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo=None,
+        )
+    assert no_ref_exc.value.code == ExitCode.API_ERROR
+
+    updated: list[OnlineSessionCheckpoint] = []
+    validate_calls: list[tuple[float, int]] = []
+
+    class _Workflow:
+        def __init__(self, sessions) -> None:
+            _ = sessions
+
+        def resume_session(self, state, *, access_token=None):
+            _ = (state, access_token)
+            return SimpleNamespace(
+                send_invoice=lambda invoice_xml, *, access_token=None: {"referenceNumber": "INV-1"}
+            )
+
+    monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _Workflow)
+
+    def _update_online_checkpoint(
+        checkpoint: OnlineSessionCheckpoint,
+        **changes: object,
+    ) -> OnlineSessionCheckpoint:
+        updated_checkpoint = replace(checkpoint, **cast(Any, changes))
+        updated.append(updated_checkpoint)
+        return updated_checkpoint
+
+    monkeypatch.setattr(
+        session_ops,
+        "update_checkpoint",
+        _update_online_checkpoint,
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_validate_polling_options",
+        lambda interval, attempts: validate_calls.append((interval, attempts)),
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_wait_for_invoice_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Accepted"}},
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_reference_number", lambda payload: "INV-1")
+    monkeypatch.setattr(
+        session_ops.adapters, "_extract_status_fields", lambda payload: (200, "Accepted", [])
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_ksef_number", lambda payload: "KSEF-1")
+    monkeypatch.setattr(session_ops.adapters, "_wait_for_invoice_upo", lambda **kwargs: b"<upo/>")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_resolve_output_path",
+        lambda save_upo, default_filename: tmp_path / default_filename,
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_save_bytes",
+        lambda path, payload, overwrite=False: Path(path),
+    )
+
+    result = session_ops.send_online_session_invoice(
+        profile="demo",
+        session_id="resume-online",
+        invoice="invoice.xml",
+        wait_status=True,
+        wait_upo=True,
+        poll_interval=0.5,
+        max_attempts=5,
+        save_upo="upo.xml",
+        save_upo_overwrite=True,
+    )
+
+    assert result["status_code"] == 200
+    assert result["ksef_number"] == "KSEF-1"
+    assert result["upo_path"].endswith("upo-SES-ONLINE-1-INV-1.xml")
+    assert validate_calls == [(0.5, 5)]
+    assert updated[-1].last_invoice_ref == "INV-1"
+
+
+def test_send_online_session_invoice_wait_upo_without_saving_returns_empty_path(
+    monkeypatch,
+) -> None:
+    checkpoint = _online_checkpoint()
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    monkeypatch.setattr(session_ops.adapters, "_load_invoice_xml", lambda invoice: b"<invoice/>")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(sessions=object()),
+    )
+    monkeypatch.setattr(
+        session_ops,
+        "OnlineSessionWorkflow",
+        lambda sessions: SimpleNamespace(
+            resume_session=lambda state, *, access_token=None: SimpleNamespace(
+                send_invoice=lambda invoice_xml, *, access_token=None: {"referenceNumber": "INV-1"}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        session_ops, "update_checkpoint", lambda cp, **changes: replace(cp, **changes)
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_reference_number", lambda payload: "INV-1")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_wait_for_invoice_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Accepted"}},
+    )
+    monkeypatch.setattr(
+        session_ops.adapters, "_extract_status_fields", lambda payload: (200, "Accepted", [])
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_ksef_number", lambda payload: "KSEF-1")
+    monkeypatch.setattr(session_ops.adapters, "_wait_for_invoice_upo", lambda **kwargs: b"<upo/>")
+
+    result = session_ops.send_online_session_invoice(
+        profile="demo",
+        session_id="resume-online",
+        invoice="invoice.xml",
+        wait_status=True,
+        wait_upo=True,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+    )
+
+    assert result["upo_path"] == ""
+
+
+def test_open_batch_session_closes_handle_when_save_fails(monkeypatch) -> None:
+    closed: list[str | None] = []
+
+    class _Handle:
+        def get_state(self) -> BatchSessionState:
+            return _batch_checkpoint().session_state
+
+        def close(self, *, access_token=None) -> None:
+            closed.append(access_token)
+
+    class _Workflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def open_session(self, **kwargs):
+            _ = kwargs
+            return _Handle()
+
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    monkeypatch.setattr(session_ops.adapters, "_build_form_code", lambda *args: _form_code())
+    monkeypatch.setattr(session_ops.adapters, "_select_certificate", lambda certs, usage: "CERT")
+    monkeypatch.setattr(
+        session_ops,
+        "_build_batch_payload_source",
+        lambda **kwargs: (b"zip!", _batch_checkpoint().payload_source),
+    )
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _Workflow)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            security=SimpleNamespace(
+                get_public_key_certificates=lambda: [{"usage": ["SymmetricKeyEncryption"]}]
+            ),
+            sessions=object(),
+            http_client=object(),
+        ),
+    )
+    monkeypatch.setattr(
+        session_ops,
+        "save_checkpoint",
+        lambda checkpoint, overwrite=False: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError):
+        session_ops.open_batch_session(
+            profile="demo",
+            base_url="https://example.invalid",
+            session_id="resume-batch",
+            zip_path="batch.zip",
+            directory=None,
+            system_code="FA (3)",
+            schema_version="1-0E",
+            form_value="FA",
+            upo_v43=True,
+        )
+    assert closed == ["token"]
+
+
+def test_upload_batch_session_validates_parallelism_and_updates_progress(monkeypatch) -> None:
+    checkpoint = _batch_checkpoint()
+
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    with pytest.raises(CliError) as exc:
+        session_ops.upload_batch_session(profile="demo", session_id="resume-batch", parallelism=0)
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+
+    updated: list[BatchSessionCheckpoint] = []
+
+    class _Handle:
+        def upload_parts(
+            self, *, parallelism=1, skip_ordinals=None, progress_callback=None
+        ) -> None:
+            _ = (parallelism, skip_ordinals)
+            if progress_callback is not None:
+                progress_callback(1)
+
+    class _Workflow:
+        def __init__(self, sessions, http_client) -> None:
+            _ = (sessions, http_client)
+
+        def resume_session(self, state, *, zip_bytes, access_token=None):
+            _ = (state, zip_bytes, access_token)
+            return _Handle()
+
+    monkeypatch.setattr(session_ops, "_load_batch_source_bytes", lambda source: b"zip!")
+    monkeypatch.setattr(session_ops, "BatchSessionWorkflow", _Workflow)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(sessions=object(), http_client=object()),
+    )
+
+    def _update_uploaded_checkpoint(
+        checkpoint: BatchSessionCheckpoint,
+        **changes: object,
+    ) -> BatchSessionCheckpoint:
+        updated_checkpoint = replace(checkpoint, **cast(Any, changes))
+        updated.append(updated_checkpoint)
+        return updated_checkpoint
+
+    monkeypatch.setattr(
+        session_ops,
+        "update_checkpoint",
+        _update_uploaded_checkpoint,
+    )
+
+    result = session_ops.upload_batch_session(
+        profile="demo",
+        session_id="resume-batch",
+        parallelism=2,
+    )
+
+    assert result["uploaded_count"] == 1
+    assert updated[-1].uploaded_ordinals == [1]
+
+
+def test_close_batch_session_validates_and_waits(monkeypatch, tmp_path: Path) -> None:
+    checkpoint = _batch_checkpoint()
+
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    with pytest.raises(CliError) as exc:
+        session_ops.close_batch_session(
+            profile="demo",
+            session_id="resume-batch",
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo="upo.xml",
+        )
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+
+    updated: list[BatchSessionCheckpoint] = []
+    validate_calls: list[tuple[float, int]] = []
+    close_calls: list[str | None] = []
+
+    class _BatchHandleClass:
+        @classmethod
+        def from_state(cls, state, *, sessions_client, uploader, access_token=None):
+            _ = (state, sessions_client, uploader)
+            return SimpleNamespace(
+                close=lambda *, access_token=None: close_calls.append(access_token)
+            )
+
+    monkeypatch.setattr(session_ops, "BatchSessionHandle", _BatchHandleClass)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(
+            sessions=object(),
+            http_client=object(),
+        ),
+    )
+
+    def _update_batch_checkpoint(
+        checkpoint: BatchSessionCheckpoint,
+        **changes: object,
+    ) -> BatchSessionCheckpoint:
+        updated_checkpoint = replace(checkpoint, **cast(Any, changes))
+        updated.append(updated_checkpoint)
+        return updated_checkpoint
+
+    monkeypatch.setattr(
+        session_ops,
+        "update_checkpoint",
+        _update_batch_checkpoint,
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_validate_polling_options",
+        lambda interval, attempts: validate_calls.append((interval, attempts)),
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_wait_for_session_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Closed"}},
+    )
+    monkeypatch.setattr(
+        session_ops.adapters, "_extract_status_fields", lambda payload: (200, "Closed", [])
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_upo_reference", lambda payload: "UPO-1")
+    monkeypatch.setattr(session_ops.adapters, "_wait_for_batch_upo", lambda **kwargs: b"<upo/>")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_resolve_output_path",
+        lambda save_upo, default_filename: tmp_path / default_filename,
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_save_bytes",
+        lambda path, payload, overwrite=False: Path(path),
+    )
+
+    result = session_ops.close_batch_session(
+        profile="demo",
+        session_id="resume-batch",
+        wait_status=True,
+        wait_upo=True,
+        poll_interval=0.5,
+        max_attempts=5,
+        save_upo="upo.xml",
+        save_upo_overwrite=True,
+    )
+
+    assert result["status_code"] == 200
+    assert result["upo_ref"] == "UPO-1"
+    assert result["upo_path"].endswith("upo-SES-BATCH-1-UPO-1.xml")
+    assert close_calls == ["token"]
+    assert validate_calls == [(0.5, 5)]
+    assert updated[-1].last_upo_ref == "UPO-1"
+
+
+def test_close_batch_session_wait_upo_requires_reference(monkeypatch) -> None:
+    checkpoint = _batch_checkpoint()
+    updated: list[BatchSessionCheckpoint] = []
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    monkeypatch.setattr(
+        session_ops,
+        "BatchSessionHandle",
+        type(
+            "_BatchHandleClass",
+            (),
+            {
+                "from_state": classmethod(
+                    lambda cls, state, *, sessions_client, uploader, access_token=None: (
+                        SimpleNamespace(close=lambda *, access_token=None: None)
+                    )
+                )
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(sessions=object(), http_client=object()),
+    )
+
+    def _update_checkpoint(
+        checkpoint: BatchSessionCheckpoint,
+        **changes: object,
+    ) -> BatchSessionCheckpoint:
+        updated_checkpoint = replace(checkpoint, **cast(Any, changes))
+        updated.append(updated_checkpoint)
+        return updated_checkpoint
+
+    monkeypatch.setattr(session_ops, "update_checkpoint", _update_checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_wait_for_session_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Closed"}},
+    )
+    monkeypatch.setattr(
+        session_ops.adapters, "_extract_status_fields", lambda payload: (200, "Closed", [])
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_upo_reference", lambda payload: None)
+
+    with pytest.raises(CliError) as exc:
+        session_ops.close_batch_session(
+            profile="demo",
+            session_id="resume-batch",
+            wait_status=True,
+            wait_upo=True,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo=None,
+        )
+    assert exc.value.code == ExitCode.RETRY_EXHAUSTED
+
+
+def test_close_batch_session_wait_upo_without_saving_returns_empty_path(monkeypatch) -> None:
+    checkpoint = _batch_checkpoint()
+    updated: list[BatchSessionCheckpoint] = []
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
+    monkeypatch.setattr(
+        session_ops,
+        "BatchSessionHandle",
+        type(
+            "_BatchHandleClass",
+            (),
+            {
+                "from_state": classmethod(
+                    lambda cls, state, *, sessions_client, uploader, access_token=None: (
+                        SimpleNamespace(close=lambda *, access_token=None: None)
+                    )
+                )
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda base_url, access_token=None: _FakeClient(sessions=object(), http_client=object()),
+    )
+
+    def _update_checkpoint(
+        checkpoint: BatchSessionCheckpoint,
+        **changes: object,
+    ) -> BatchSessionCheckpoint:
+        updated_checkpoint = replace(checkpoint, **cast(Any, changes))
+        updated.append(updated_checkpoint)
+        return updated_checkpoint
+
+    monkeypatch.setattr(session_ops, "update_checkpoint", _update_checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_wait_for_session_status",
+        lambda **kwargs: {"status": {"code": 200, "description": "Closed"}},
+    )
+    monkeypatch.setattr(
+        session_ops.adapters, "_extract_status_fields", lambda payload: (200, "Closed", [])
+    )
+    monkeypatch.setattr(session_ops.adapters, "_extract_upo_reference", lambda payload: "UPO-1")
+    monkeypatch.setattr(session_ops.adapters, "_wait_for_batch_upo", lambda **kwargs: b"<upo/>")
+
+    result = session_ops.close_batch_session(
+        profile="demo",
+        session_id="resume-batch",
+        wait_status=True,
+        wait_upo=True,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+    )
+
+    assert result["upo_path"] == ""

--- a/tests/cli/unit/test_session_store.py
+++ b/tests/cli/unit/test_session_store.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import ksef_client.cli.session_store as session_store
 from ksef_client import models as m
 from ksef_client.cli.errors import CliError
 from ksef_client.cli.session_store import (
@@ -54,9 +55,7 @@ def _batch_checkpoint() -> BatchSessionCheckpoint:
                 {
                     "fileSize": 10,
                     "fileHash": "hash",
-                    "fileParts": [
-                        {"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}
-                    ],
+                    "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}],
                 }
             ),
             part_upload_requests=[
@@ -90,8 +89,10 @@ def test_session_store_roundtrip_and_list(monkeypatch, tmp_path: Path) -> None:
 
     loaded = load_checkpoint("demo", checkpoint.id)
     assert loaded.to_dict() == checkpoint.to_dict()
+    assert isinstance(loaded, OnlineSessionCheckpoint)
 
     updated = update_checkpoint(loaded, stage="closed", last_invoice_ref="INV-1")
+    assert isinstance(updated, OnlineSessionCheckpoint)
     assert updated.stage == "closed"
     assert updated.last_invoice_ref == "INV-1"
 
@@ -160,3 +161,231 @@ def test_session_store_skips_corrupted_items_in_list(monkeypatch, tmp_path: Path
 
     listed = list_checkpoints("demo")
     assert [item.id for item in listed] == [checkpoint.id]
+
+
+@pytest.mark.parametrize(
+    ("helper_name", "value"),
+    [
+        ("_optional_string", 1),
+        ("_required_string", " "),
+        ("_required_int", -1),
+        ("_required_string_list", {"bad": True}),
+        ("_required_string_list", ["ok", 2]),
+        ("_required_int_list", {"bad": True}),
+        ("_required_int_list", [1, -1]),
+    ],
+)
+def test_session_store_private_validators_reject_invalid_values(
+    helper_name: str, value: object
+) -> None:
+    helper = getattr(session_store, helper_name)
+    with pytest.raises(ValueError):
+        helper(value, field_name="field")
+
+
+def test_session_store_rejects_invalid_ids_and_checkpoint_shapes() -> None:
+    with pytest.raises(CliError):
+        session_store._validate_session_id(" bad id ")
+
+    with pytest.raises(ValueError):
+        BatchPayloadSource(kind="bad", path="x", source_sha256_base64="hash", source_size=1)
+    with pytest.raises(ValueError):
+        BatchPayloadSource(kind="zip", path=" ", source_sha256_base64="hash", source_size=1)
+    with pytest.raises(ValueError):
+        BatchPayloadSource(kind="zip", path="x", source_sha256_base64="hash", source_size=-1)
+    with pytest.raises(ValueError):
+        BatchPayloadSource(kind="zip", path="x", source_sha256_base64=" ", source_size=1)
+
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint(
+            id="online-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_online_checkpoint().session_state,
+            schema_version=2,
+        )
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint(
+            id="online-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_online_checkpoint().session_state,
+            kind="batch",
+        )
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint(
+            id="online-demo",
+            profile=" ",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_online_checkpoint().session_state,
+        )
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint(
+            id="online-demo",
+            profile="demo",
+            base_url=" ",
+            stage="opened",
+            session_state=_online_checkpoint().session_state,
+        )
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint(
+            id="online-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage=" ",
+            session_state=_online_checkpoint().session_state,
+        )
+
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint(
+            id="batch-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_batch_checkpoint().session_state,
+            payload_source=_batch_checkpoint().payload_source,
+            schema_version=2,
+        )
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint(
+            id="batch-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_batch_checkpoint().session_state,
+            payload_source=_batch_checkpoint().payload_source,
+            kind="online",
+        )
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint(
+            id="batch-demo",
+            profile=" ",
+            base_url="https://example.invalid",
+            stage="opened",
+            session_state=_batch_checkpoint().session_state,
+            payload_source=_batch_checkpoint().payload_source,
+        )
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint(
+            id="batch-demo",
+            profile="demo",
+            base_url=" ",
+            stage="opened",
+            session_state=_batch_checkpoint().session_state,
+            payload_source=_batch_checkpoint().payload_source,
+        )
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint(
+            id="batch-demo",
+            profile="demo",
+            base_url="https://example.invalid",
+            stage=" ",
+            session_state=_batch_checkpoint().session_state,
+            payload_source=_batch_checkpoint().payload_source,
+        )
+
+
+def test_session_store_checkpoint_from_dict_rejects_invalid_shapes() -> None:
+    online_payload = _online_checkpoint().to_dict()
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint.from_dict(online_payload | {"schema_version": 2})
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint.from_dict(online_payload | {"kind": "batch"})
+    with pytest.raises(ValueError):
+        OnlineSessionCheckpoint.from_dict(online_payload | {"session_state": []})
+
+    batch_payload = _batch_checkpoint().to_dict()
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint.from_dict(batch_payload | {"schema_version": 2})
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint.from_dict(batch_payload | {"kind": "online"})
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint.from_dict(batch_payload | {"session_state": []})
+    with pytest.raises(ValueError):
+        BatchSessionCheckpoint.from_dict(batch_payload | {"payload_source": []})
+
+    with pytest.raises(CliError):
+        session_store.checkpoint_from_dict({"kind": "online"})
+    with pytest.raises(CliError):
+        session_store.checkpoint_from_dict({"kind": "mystery"})
+
+
+def test_session_store_handles_atomic_write_errors_and_posix_permissions(
+    monkeypatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "checkpoint.json"
+    chmod_calls: list[tuple[Path, int]] = []
+
+    monkeypatch.setattr(session_store.os, "name", "posix", raising=False)
+    monkeypatch.setattr(
+        session_store.os,
+        "chmod",
+        lambda path, mode: chmod_calls.append((Path(path), mode)),
+    )
+    session_store._write_json_atomic(target, {"id": "ok"})
+    assert target.exists()
+    assert [(Path(path).as_posix(), mode) for path, mode in chmod_calls] == [
+        (target.as_posix(), 0o600)
+    ]
+
+    def _boom_replace(src: str, dst: str) -> None:
+        raise OSError("nope")
+
+    monkeypatch.setattr(session_store.os, "replace", _boom_replace)
+    with pytest.raises(CliError):
+        session_store._write_json_atomic(tmp_path / "broken.json", {"id": "bad"})
+
+
+def test_session_store_handles_read_and_delete_failures(monkeypatch, tmp_path: Path) -> None:
+    non_object = tmp_path / "non-object.json"
+    non_object.write_text("[]", encoding="utf-8")
+    with pytest.raises(CliError):
+        session_store._read_json(non_object)
+
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    assert list_checkpoints("missing") == []
+
+    with pytest.raises(CliError):
+        load_checkpoint("demo", "missing")
+
+    checkpoint = _online_checkpoint()
+    save_checkpoint(checkpoint)
+    with pytest.raises(CliError):
+        delete_checkpoint("demo", "missing")
+
+    def _boom_unlink(self) -> None:
+        _ = self
+        raise OSError("locked")
+
+    monkeypatch.setattr(Path, "unlink", _boom_unlink)
+    with pytest.raises(CliError):
+        delete_checkpoint("demo", checkpoint.id)
+
+
+def test_session_store_export_trailing_slash_and_import_missing_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _online_checkpoint()
+    save_checkpoint(checkpoint)
+
+    export_root = tmp_path / "exports"
+
+    class _TrailingSlashPath:
+        def exists(self) -> bool:
+            return False
+
+        def is_dir(self) -> bool:
+            return False
+
+        def __str__(self) -> str:
+            return f"{export_root.as_posix()}/"
+
+    exported = export_checkpoint("demo", checkpoint.id, _TrailingSlashPath())  # type: ignore[arg-type]
+    assert exported.name == f"session-{checkpoint.id}.json"
+
+    with pytest.raises(CliError):
+        import_checkpoint("demo", tmp_path / "missing.json")

--- a/tests/cli/unit/test_session_store.py
+++ b/tests/cli/unit/test_session_store.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ksef_client import models as m
+from ksef_client.cli.errors import CliError
+from ksef_client.cli.session_store import (
+    BatchPayloadSource,
+    BatchSessionCheckpoint,
+    OnlineSessionCheckpoint,
+    delete_checkpoint,
+    export_checkpoint,
+    import_checkpoint,
+    list_checkpoints,
+    load_checkpoint,
+    save_checkpoint,
+    update_checkpoint,
+)
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def _online_checkpoint() -> OnlineSessionCheckpoint:
+    return OnlineSessionCheckpoint(
+        id="online-demo",
+        profile="demo",
+        base_url="https://api-demo.ksef.mf.gov.pl",
+        stage="opened",
+        session_state=OnlineSessionState(
+            reference_number="SES-ONLINE-1",
+            form_code=_form_code(),
+            valid_until="2026-04-01T12:30:00Z",
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+        ),
+    )
+
+
+def _batch_checkpoint() -> BatchSessionCheckpoint:
+    return BatchSessionCheckpoint(
+        id="batch-demo",
+        profile="demo",
+        base_url="https://api-demo.ksef.mf.gov.pl",
+        stage="opened",
+        session_state=BatchSessionState(
+            reference_number="SES-BATCH-1",
+            form_code=_form_code(),
+            batch_file=m.BatchFileInfo.from_dict(
+                {
+                    "fileSize": 10,
+                    "fileHash": "hash",
+                    "fileParts": [
+                        {"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}
+                    ],
+                }
+            ),
+            part_upload_requests=[
+                m.PartUploadRequest.from_dict(
+                    {
+                        "ordinalNumber": 1,
+                        "url": "https://upload/1",
+                        "method": "PUT",
+                        "headers": {},
+                    }
+                )
+            ],
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+        ),
+        payload_source=BatchPayloadSource(
+            kind="zip",
+            path="C:/tmp/invoices.zip",
+            source_sha256_base64="hash",
+            source_size=10,
+        ),
+    )
+
+
+def test_session_store_roundtrip_and_list(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _online_checkpoint()
+
+    saved_path = save_checkpoint(checkpoint)
+    assert saved_path.exists()
+
+    loaded = load_checkpoint("demo", checkpoint.id)
+    assert loaded.to_dict() == checkpoint.to_dict()
+
+    updated = update_checkpoint(loaded, stage="closed", last_invoice_ref="INV-1")
+    assert updated.stage == "closed"
+    assert updated.last_invoice_ref == "INV-1"
+
+    listed = list_checkpoints("demo")
+    assert [item.id for item in listed] == [checkpoint.id]
+
+
+def test_session_store_export_import_delete_and_overwrite(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _batch_checkpoint()
+    save_checkpoint(checkpoint)
+
+    export_dir = tmp_path / "exports"
+    export_dir.mkdir()
+    exported = export_checkpoint("demo", checkpoint.id, export_dir)
+    assert exported.exists()
+
+    delete_checkpoint("demo", checkpoint.id)
+    assert list_checkpoints("demo") == []
+
+    imported = import_checkpoint("demo", exported)
+    assert imported.id == checkpoint.id
+
+    replaced = import_checkpoint("demo", exported, session_id="batch-other")
+    assert replaced.id == "batch-other"
+    assert load_checkpoint("demo", "batch-other").id == "batch-other"
+
+
+def test_session_store_rejects_invalid_payload_and_profile_mismatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _online_checkpoint()
+    save_checkpoint(checkpoint)
+
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text("{bad", encoding="utf-8")
+    with pytest.raises(CliError):
+        import_checkpoint("demo", bad_path)
+
+    mismatch_path = tmp_path / "mismatch.json"
+    payload = checkpoint.to_dict()
+    payload["profile"] = "other"
+    mismatch_path.write_text(__import__("json").dumps(payload), encoding="utf-8")
+    with pytest.raises(CliError):
+        import_checkpoint("demo", mismatch_path)
+
+
+def test_session_store_rejects_duplicate_id_without_overwrite(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _online_checkpoint()
+    save_checkpoint(checkpoint)
+
+    with pytest.raises(CliError):
+        save_checkpoint(checkpoint, overwrite=False)
+
+
+def test_session_store_skips_corrupted_items_in_list(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    checkpoint = _online_checkpoint()
+    save_checkpoint(checkpoint)
+
+    broken_path = tmp_path / "local" / "ksef-cli" / "sessions" / "demo" / "broken.json"
+    broken_path.parent.mkdir(parents=True, exist_ok=True)
+    broken_path.write_text("{", encoding="utf-8")
+
+    listed = list_checkpoints("demo")
+    assert [item.id for item in listed] == [checkpoint.id]

--- a/tests/test_e2e_resume_flows.py
+++ b/tests/test_e2e_resume_flows.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import time
+from contextlib import suppress
+
+import pytest
+
+from ksef_client import KsefClient, KsefClientOptions
+from ksef_client import models as m
+from ksef_client.services import BatchSessionWorkflow, OnlineSessionWorkflow
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+from ksef_client.utils.zip_utils import build_zip
+from tests.test_e2e_token_flows import (
+    FORM_CODE,
+    E2EConfig,
+    _authenticate_access_token,
+    _build_invoice_xml,
+    _ensure_e2e_enabled,
+    _load_demo_token_config,
+    _load_test_token_config,
+    _poll_for_ksef_number,
+    _poll_for_upo,
+    _select_certificate,
+    _with_rate_limit_retry,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+def _poll_for_session_completion(
+    client: KsefClient,
+    *,
+    session_reference_number: str,
+    access_token: str,
+    require_upo_reference: bool = False,
+) -> m.SessionStatusResponse:
+    max_attempts = 45
+    poll_interval = 2.0
+
+    for _ in range(max_attempts):
+        status = _with_rate_limit_retry(
+            lambda: client.sessions.get_session_status(
+                session_reference_number,
+                access_token=access_token,
+            )
+        )
+        code = int(status.status.code)
+        if code == 200 and (not require_upo_reference or _extract_upo_reference(status)):
+            return status
+        if code not in {100, 150}:
+            raise AssertionError(f"Session processing failed with status code {code}.")
+        time.sleep(poll_interval)
+    raise TimeoutError("Session processing did not complete within max_attempts.")
+
+
+def _extract_upo_reference(status: m.SessionStatusResponse) -> str | None:
+    upo = getattr(status, "upo", None)
+    if upo is None:
+        return None
+    pages = getattr(upo, "pages", None)
+    if not pages:
+        return None
+    reference_number = getattr(pages[0], "reference_number", None)
+    if isinstance(reference_number, str) and reference_number:
+        return reference_number
+    return None
+
+
+def _build_batch_zip(*, seller_nip: str, environment_name: str) -> bytes:
+    invoice_xml = _build_invoice_xml(seller_nip=seller_nip, environment_name=environment_name)
+    return build_zip({"invoice-1.xml": invoice_xml})
+
+
+def _run_online_resume_flow(config: E2EConfig) -> None:
+    if config.context_type.lower() != "nip":
+        raise RuntimeError("This E2E scenario requires context_type='nip'.")
+
+    options = KsefClientOptions(base_url=config.base_url)
+    access_token: str | None = None
+    session_state: OnlineSessionState | None = None
+
+    with KsefClient(options) as open_client:
+        certs = _with_rate_limit_retry(lambda: open_client.security.get_public_key_certificates())
+        token_cert = _select_certificate(certs, "KsefTokenEncryption")
+        symmetric_cert = _select_certificate(certs, "SymmetricKeyEncryption")
+        access_token = _authenticate_access_token(
+            open_client,
+            config=config,
+            token_cert=token_cert,
+        )
+
+        session = OnlineSessionWorkflow(open_client.sessions).open_session(
+            form_code=FORM_CODE,
+            public_certificate=symmetric_cert,
+            access_token=access_token,
+        )
+        session_state = OnlineSessionState.from_json(session.get_state().to_json())
+
+    assert access_token, "Authentication did not return access token."
+    assert session_state is not None, "Online session state was not created."
+    assert access_token not in session_state.to_json()
+
+    with KsefClient(options) as resumed_client:
+        resumed = OnlineSessionWorkflow(resumed_client.sessions).resume_session(
+            session_state,
+            access_token=access_token,
+        )
+        try:
+            send_result = resumed.send_invoice(
+                _build_invoice_xml(
+                    seller_nip=config.context_value,
+                    environment_name=f"{config.name}-resume",
+                ),
+                access_token=access_token,
+            )
+            invoice_reference_number = send_result.reference_number
+            assert isinstance(invoice_reference_number, str) and invoice_reference_number, (
+                "Missing invoice reference number after resumed send."
+            )
+
+            invoice_status = _with_rate_limit_retry(
+                lambda: resumed.get_invoice_status(
+                    invoice_reference_number,
+                    access_token=access_token,
+                )
+            )
+            assert int(invoice_status.status.code) in {100, 150, 200}
+
+            ksef_number = _poll_for_ksef_number(
+                resumed_client,
+                resumed.session_reference_number,
+                invoice_reference_number,
+                access_token,
+            )
+            upo_bytes = _poll_for_upo(
+                lambda: resumed.get_invoice_upo_by_ksef(
+                    ksef_number,
+                    access_token=access_token,
+                )
+            )
+            assert upo_bytes, "Received empty invoice UPO after resumed online session."
+
+            session_invoices = _with_rate_limit_retry(
+                lambda: resumed.list_invoices(page_size=20, access_token=access_token)
+            )
+            assert any(
+                invoice.reference_number == invoice_reference_number
+                for invoice in session_invoices.invoices
+            ), "Resumed online session did not list the sent invoice."
+        finally:
+            with suppress(Exception):
+                resumed.close(access_token=access_token)
+
+
+def _run_batch_resume_flow(config: E2EConfig) -> None:
+    if config.context_type.lower() != "nip":
+        raise RuntimeError("This E2E scenario requires context_type='nip'.")
+
+    options = KsefClientOptions(base_url=config.base_url)
+    access_token: str | None = None
+    session_state: BatchSessionState | None = None
+    batch_zip = _build_batch_zip(
+        seller_nip=config.context_value,
+        environment_name=f"{config.name}-batch-resume",
+    )
+
+    with KsefClient(options) as open_client:
+        certs = _with_rate_limit_retry(lambda: open_client.security.get_public_key_certificates())
+        token_cert = _select_certificate(certs, "KsefTokenEncryption")
+        symmetric_cert = _select_certificate(certs, "SymmetricKeyEncryption")
+        access_token = _authenticate_access_token(
+            open_client,
+            config=config,
+            token_cert=token_cert,
+        )
+
+        session = BatchSessionWorkflow(open_client.sessions, open_client.http_client).open_session(
+            form_code=FORM_CODE,
+            zip_bytes=batch_zip,
+            public_certificate=symmetric_cert,
+            access_token=access_token,
+        )
+        session_state = BatchSessionState.from_json(session.get_state().to_json())
+
+    assert access_token, "Authentication did not return access token."
+    assert session_state is not None, "Batch session state was not created."
+    assert access_token not in session_state.to_json()
+
+    with KsefClient(options) as resumed_client:
+        resumed = BatchSessionWorkflow(
+            resumed_client.sessions,
+            resumed_client.http_client,
+        ).resume_session(
+            session_state,
+            zip_bytes=batch_zip,
+            access_token=access_token,
+        )
+        uploaded_ordinals: list[int] = []
+
+        try:
+            resumed.upload_parts(
+                parallelism=1,
+                progress_callback=uploaded_ordinals.append,
+            )
+            assert uploaded_ordinals, "Batch resume did not upload any parts."
+
+            resumed.close(access_token=access_token)
+
+            session_status = _poll_for_session_completion(
+                resumed_client,
+                session_reference_number=resumed.session_reference_number,
+                access_token=access_token,
+                require_upo_reference=True,
+            )
+            assert int(session_status.status.code) == 200
+
+            upo_reference_number = _extract_upo_reference(session_status)
+            assert upo_reference_number, "Batch session completion did not expose UPO reference."
+
+            upo_bytes = _poll_for_upo(
+                lambda: resumed.get_upo(
+                    upo_reference_number,
+                    access_token=access_token,
+                )
+            )
+            assert upo_bytes, "Received empty batch UPO after resumed batch session."
+
+            session_invoices = _with_rate_limit_retry(
+                lambda: resumed.list_invoices(page_size=20, access_token=access_token)
+            )
+            failed_invoices = _with_rate_limit_retry(
+                lambda: resumed.list_failed_invoices(page_size=20, access_token=access_token)
+            )
+            assert session_invoices.invoices or failed_invoices.invoices, (
+                "Resumed batch session did not report any processed invoices."
+            )
+        finally:
+            with suppress(Exception):
+                resumed.close(access_token=access_token)
+
+
+def test_e2e_test_environment_online_resume_token() -> None:
+    _ensure_e2e_enabled()
+    _run_online_resume_flow(_load_test_token_config())
+
+
+def test_e2e_test_environment_batch_resume_token() -> None:
+    _ensure_e2e_enabled()
+    _run_batch_resume_flow(_load_test_token_config())
+
+
+def test_e2e_demo_environment_online_resume_token() -> None:
+    _ensure_e2e_enabled()
+    _run_online_resume_flow(_load_demo_token_config())
+
+
+def test_e2e_demo_environment_batch_resume_token() -> None:
+    _ensure_e2e_enabled()
+    _run_batch_resume_flow(_load_demo_token_config())

--- a/tests/test_e2e_resume_flows.py
+++ b/tests/test_e2e_resume_flows.py
@@ -16,6 +16,8 @@ from tests.test_e2e_token_flows import (
     _authenticate_access_token,
     _build_invoice_xml,
     _ensure_e2e_enabled,
+    _env_float,
+    _env_int,
     _load_demo_token_config,
     _load_test_token_config,
     _poll_for_ksef_number,
@@ -34,8 +36,8 @@ def _poll_for_session_completion(
     access_token: str,
     require_upo_reference: bool = False,
 ) -> m.SessionStatusResponse:
-    max_attempts = 45
-    poll_interval = 2.0
+    max_attempts = _env_int("KSEF_E2E_SESSION_MAX_ATTEMPTS", 90)
+    poll_interval = _env_float("KSEF_E2E_POLL_INTERVAL_SECONDS", 2.0)
 
     for _ in range(max_attempts):
         status = _with_rate_limit_retry(
@@ -89,10 +91,12 @@ def _run_online_resume_flow(config: E2EConfig) -> None:
             token_cert=token_cert,
         )
 
-        session = OnlineSessionWorkflow(open_client.sessions).open_session(
-            form_code=FORM_CODE,
-            public_certificate=symmetric_cert,
-            access_token=access_token,
+        session = _with_rate_limit_retry(
+            lambda: OnlineSessionWorkflow(open_client.sessions).open_session(
+                form_code=FORM_CODE,
+                public_certificate=symmetric_cert,
+                access_token=access_token,
+            )
         )
         session_state = OnlineSessionState.from_json(session.get_state().to_json())
 
@@ -106,12 +110,14 @@ def _run_online_resume_flow(config: E2EConfig) -> None:
             access_token=access_token,
         )
         try:
-            send_result = resumed.send_invoice(
-                _build_invoice_xml(
-                    seller_nip=config.context_value,
-                    environment_name=f"{config.name}-resume",
-                ),
-                access_token=access_token,
+            send_result = _with_rate_limit_retry(
+                lambda: resumed.send_invoice(
+                    _build_invoice_xml(
+                        seller_nip=config.context_value,
+                        environment_name=f"{config.name}-resume",
+                    ),
+                    access_token=access_token,
+                )
             )
             invoice_reference_number = send_result.reference_number
             assert isinstance(invoice_reference_number, str) and invoice_reference_number, (
@@ -149,7 +155,7 @@ def _run_online_resume_flow(config: E2EConfig) -> None:
             ), "Resumed online session did not list the sent invoice."
         finally:
             with suppress(Exception):
-                resumed.close(access_token=access_token)
+                _with_rate_limit_retry(lambda: resumed.close(access_token=access_token))
 
 
 def _run_batch_resume_flow(config: E2EConfig) -> None:
@@ -174,11 +180,16 @@ def _run_batch_resume_flow(config: E2EConfig) -> None:
             token_cert=token_cert,
         )
 
-        session = BatchSessionWorkflow(open_client.sessions, open_client.http_client).open_session(
-            form_code=FORM_CODE,
-            zip_bytes=batch_zip,
-            public_certificate=symmetric_cert,
-            access_token=access_token,
+        session = _with_rate_limit_retry(
+            lambda: BatchSessionWorkflow(
+                open_client.sessions,
+                open_client.http_client,
+            ).open_session(
+                form_code=FORM_CODE,
+                zip_bytes=batch_zip,
+                public_certificate=symmetric_cert,
+                access_token=access_token,
+            )
         )
         session_state = BatchSessionState.from_json(session.get_state().to_json())
 
@@ -204,7 +215,7 @@ def _run_batch_resume_flow(config: E2EConfig) -> None:
             )
             assert uploaded_ordinals, "Batch resume did not upload any parts."
 
-            resumed.close(access_token=access_token)
+            _with_rate_limit_retry(lambda: resumed.close(access_token=access_token))
 
             session_status = _poll_for_session_completion(
                 resumed_client,
@@ -236,7 +247,7 @@ def _run_batch_resume_flow(config: E2EConfig) -> None:
             )
         finally:
             with suppress(Exception):
-                resumed.close(access_token=access_token)
+                _with_rate_limit_retry(lambda: resumed.close(access_token=access_token))
 
 
 def test_e2e_test_environment_online_resume_token() -> None:

--- a/tests/test_services_sessions.py
+++ b/tests/test_services_sessions.py
@@ -7,8 +7,14 @@ from typing import Any
 import pytest
 
 from ksef_client import models as m
-from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+from ksef_client.services.sessions import (
+    AsyncBatchSessionHandle,
+    BatchSessionHandle,
+    BatchSessionState,
+    OnlineSessionState,
+)
 from ksef_client.services.workflows import (
+    AsyncBatchSessionWorkflow,
     AsyncBatchUploadHelper,
     AsyncOnlineSessionWorkflow,
     BatchSessionWorkflow,
@@ -98,7 +104,7 @@ class _RecordingAsyncHttp:
 
 class _StubSessionsClient:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, Any]] = []
+        self.calls: list[tuple[Any, ...]] = []
         self._batch_requests = 0
 
     def open_online_session(self, payload, *, access_token=None, upo_v43=False):
@@ -298,6 +304,99 @@ def test_batch_session_state_roundtrip_and_validation() -> None:
         BatchSessionState.from_dict(state.to_dict() | {"iv_base64": "###"})
 
 
+def test_session_states_cover_validation_error_paths() -> None:
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_json("[]")
+    with pytest.raises(ValueError):
+        OnlineSessionState(
+            reference_number="SES-1",
+            form_code=_form_code(),
+            valid_until="2026-04-01T12:30:00Z",
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+            schema_version=2,
+        )
+    with pytest.raises(ValueError):
+        OnlineSessionState(
+            reference_number="SES-1",
+            form_code=_form_code(),
+            valid_until="2026-04-01T12:30:00Z",
+            symmetric_key_base64="AQID",
+            iv_base64="BAUG",
+            kind="batch",
+        )
+
+    online_state = OnlineSessionState(
+        reference_number="SES-1",
+        form_code=_form_code(),
+        valid_until="2026-04-01T12:30:00Z",
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(online_state.to_dict() | {"reference_number": " "})
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(online_state.to_dict() | {"valid_until": 1})
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(online_state.to_dict() | {"symmetric_key_base64": 1})
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(online_state.to_dict() | {"iv_base64": 1})
+
+    batch_state = BatchSessionState(
+        reference_number="SES-BATCH",
+        form_code=_form_code(),
+        batch_file=m.BatchFileInfo.from_dict(
+            {
+                "fileSize": 10,
+                "fileHash": "hash",
+                "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}],
+            }
+        ),
+        part_upload_requests=[
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 1,
+                    "url": "https://upload/1",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            )
+        ],
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+    with pytest.raises(ValueError):
+        BatchSessionState(
+            reference_number=batch_state.reference_number,
+            form_code=batch_state.form_code,
+            batch_file=batch_state.batch_file,
+            part_upload_requests=batch_state.part_upload_requests,
+            symmetric_key_base64=batch_state.symmetric_key_base64,
+            iv_base64=batch_state.iv_base64,
+            schema_version=2,
+        )
+    with pytest.raises(ValueError):
+        BatchSessionState(
+            reference_number=batch_state.reference_number,
+            form_code=batch_state.form_code,
+            batch_file=batch_state.batch_file,
+            part_upload_requests=batch_state.part_upload_requests,
+            symmetric_key_base64=batch_state.symmetric_key_base64,
+            iv_base64=batch_state.iv_base64,
+            kind="online",
+        )
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(batch_state.to_dict() | {"reference_number": " "})
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(batch_state.to_dict() | {"symmetric_key_base64": 1})
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(batch_state.to_dict() | {"iv_base64": 1})
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(batch_state.to_dict() | {"offline_mode": "yes"})
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(batch_state.to_dict() | {"part_upload_requests": {}})
+
+
 def test_online_workflow_returns_handle_and_resume_supports_status_methods() -> None:
     sessions = _StubSessionsClient()
     workflow = OnlineSessionWorkflow(sessions)
@@ -320,6 +419,28 @@ def test_online_workflow_returns_handle_and_resume_supports_status_methods() -> 
     assert resumed.get_invoice_upo_by_ksef("KSEF-1") == b"<upo-by-ksef/>"
     assert resumed.get_upo("UPO-1") == b"<upo-session/>"
     resumed.close()
+
+
+def test_online_handle_send_and_list_operations_cover_sync_paths() -> None:
+    sessions = _StubSessionsClient()
+    workflow = OnlineSessionWorkflow(sessions)
+    rsa_cert = generate_rsa_cert()
+
+    session = workflow.open_session(
+        form_code=_form_code(),
+        public_certificate=rsa_cert.certificate_pem,
+        access_token="token",
+    )
+
+    response = session.send_invoice(
+        b"<faktura/>",
+        offline_mode=True,
+        hash_of_corrected_invoice="HASH-1",
+    )
+
+    assert response.reference_number == "INV-1"
+    assert session.list_invoices().invoices == []
+    assert session.list_failed_invoices().invoices == []
 
 
 def test_batch_workflow_resume_validates_zip_and_upload_progress() -> None:
@@ -362,6 +483,49 @@ def test_batch_workflow_resume_validates_zip_and_upload_progress() -> None:
         )
 
 
+def test_batch_handle_from_state_without_zip_covers_error_and_status_methods() -> None:
+    sessions = _StubSessionsClient()
+    uploader = BatchUploadHelper(_RecordingHttp())
+    state = BatchSessionState(
+        reference_number="SES-BATCH-1",
+        form_code=_form_code(),
+        batch_file=m.BatchFileInfo.from_dict(
+            {
+                "fileSize": 10,
+                "fileHash": "hash",
+                "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}],
+            }
+        ),
+        part_upload_requests=[
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 1,
+                    "url": "https://upload/1",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            )
+        ],
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+    )
+
+    handle = BatchSessionHandle.from_state(
+        state,
+        sessions_client=sessions,
+        uploader=uploader,
+        access_token="token",
+    )
+
+    assert handle.session_reference_number == "SES-BATCH-1"
+    assert handle.get_status().status.code == 200
+    assert handle.list_invoices().invoices == []
+    assert handle.list_failed_invoices().invoices == []
+    assert handle.get_upo("UPO-1") == b"<upo-session/>"
+    with pytest.raises(ValueError):
+        handle.upload_parts()
+
+
 def test_async_online_workflow_resume_supports_handle_methods() -> None:
     async def _run() -> None:
         sessions = _StubAsyncSessionsClient()
@@ -378,6 +542,29 @@ def test_async_online_workflow_resume_supports_handle_methods() -> None:
         status = await resumed.get_status()
         assert status.status.code == 200
         await resumed.close()
+
+    asyncio.run(_run())
+
+
+def test_async_online_handle_covers_listing_and_upo_methods() -> None:
+    async def _run() -> None:
+        sessions = _StubAsyncSessionsClient()
+        workflow = AsyncOnlineSessionWorkflow(sessions)
+        rsa_cert = generate_rsa_cert()
+
+        session = await workflow.open_session(
+            form_code=_form_code(),
+            public_certificate=rsa_cert.certificate_pem,
+            access_token="token",
+        )
+
+        assert session.session_reference_number == "SES-ONLINE-1"
+        await session.list_invoices()
+        await session.list_failed_invoices()
+        assert (await session.get_invoice_status("INV-1")).reference_number == "INV-1"
+        assert await session.get_invoice_upo_by_ref("INV-1") == b"<upo-by-ref/>"
+        assert await session.get_invoice_upo_by_ksef("KSEF-1") == b"<upo-by-ksef/>"
+        assert await session.get_upo("UPO-1") == b"<upo-session/>"
 
     asyncio.run(_run())
 
@@ -415,6 +602,58 @@ def test_async_batch_upload_helper_supports_skip_and_progress() -> None:
 
         assert seen == [2]
         assert len(http.calls) == 1
+
+    asyncio.run(_run())
+
+
+def test_async_batch_workflow_resume_covers_handle_methods_and_validation() -> None:
+    async def _run() -> None:
+        sessions = _StubAsyncSessionsClient()
+        http = _RecordingAsyncHttp()
+        workflow = AsyncBatchSessionWorkflow(sessions, http)
+        rsa_cert = generate_rsa_cert()
+        zip_bytes = build_zip({"a.xml": b"<a/>"})
+
+        session = await workflow.open_session(
+            form_code=_form_code(),
+            zip_bytes=zip_bytes,
+            public_certificate=rsa_cert.certificate_pem,
+            access_token="token",
+        )
+        assert session.session_reference_number == "SES-BATCH-1"
+
+        resumed = workflow.resume_session(
+            session.get_state(),
+            zip_bytes=zip_bytes,
+            access_token="token",
+        )
+        assert resumed.session_reference_number == "SES-BATCH-1"
+        assert resumed.get_state().reference_number == "SES-BATCH-1"
+
+        seen: list[int] = []
+        await resumed.upload_parts(progress_callback=lambda ordinal: seen.append(ordinal))
+        assert seen == [1]
+        assert (await resumed.get_status()).status.code == 200
+        assert (await resumed.list_invoices()).invoices == []
+        assert (await resumed.list_failed_invoices()).invoices == []
+        assert await resumed.get_upo("UPO-1") == b"<upo-session/>"
+        await resumed.close()
+
+        detached = AsyncBatchSessionHandle.from_state(
+            session.get_state(),
+            sessions_client=sessions,
+            uploader=AsyncBatchUploadHelper(http),
+            access_token="token",
+        )
+        with pytest.raises(ValueError):
+            await detached.upload_parts()
+
+        with pytest.raises(ValueError):
+            workflow.resume_session(
+                session.get_state(),
+                zip_bytes=build_zip({"changed.xml": b"<x/>"}),
+                access_token="token",
+            )
 
     asyncio.run(_run())
 

--- a/tests/test_services_sessions.py
+++ b/tests/test_services_sessions.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from ksef_client import models as m
+from ksef_client.services.sessions import BatchSessionState, OnlineSessionState
+from ksef_client.services.workflows import (
+    AsyncBatchUploadHelper,
+    AsyncOnlineSessionWorkflow,
+    BatchSessionWorkflow,
+    BatchUploadHelper,
+    OnlineSessionHandle,
+    OnlineSessionWorkflow,
+)
+from ksef_client.utils.zip_utils import build_zip
+from tests.helpers import generate_rsa_cert
+
+
+def _form_code() -> m.FormCode:
+    return m.FormCode(system_code="FA (3)", schema_version="1-0E", value="FA")
+
+
+def _status_payload() -> m.SessionStatusResponse:
+    return m.SessionStatusResponse.from_dict(
+        {
+            "dateCreated": "2026-04-01T12:00:00Z",
+            "dateUpdated": "2026-04-01T12:01:00Z",
+            "status": {"code": 200, "description": "OK"},
+            "invoiceCount": 1,
+            "successfulInvoiceCount": 1,
+            "failedInvoiceCount": 0,
+        }
+    )
+
+
+def _invoice_status_payload() -> m.SessionInvoiceStatusResponse:
+    return m.SessionInvoiceStatusResponse.from_dict(
+        {
+            "status": {"code": 200, "description": "Accepted"},
+            "referenceNumber": "INV-1",
+            "invoiceHash": "hash",
+            "invoicingDate": "2026-04-01T12:00:00Z",
+            "ordinalNumber": 1,
+        }
+    )
+
+
+def _open_online_session_response() -> m.OpenOnlineSessionResponse:
+    return m.OpenOnlineSessionResponse.from_dict(
+        {"referenceNumber": "SES-ONLINE-1", "validUntil": "2026-04-01T12:30:00Z"}
+    )
+
+
+def _open_batch_session_response(request_count: int) -> m.OpenBatchSessionResponse:
+    return m.OpenBatchSessionResponse.from_dict(
+        {
+            "referenceNumber": "SES-BATCH-1",
+            "partUploadRequests": [
+                {
+                    "ordinalNumber": index,
+                    "url": f"https://upload/{index}",
+                    "method": "PUT",
+                    "headers": {"x-ms-blob-type": "BlockBlob"},
+                }
+                for index in range(1, request_count + 1)
+            ],
+        }
+    )
+
+
+@dataclass
+class _RecordingHttp:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def request(self, *args: Any, **kwargs: Any):
+        self.calls.append((args, kwargs))
+        return type("Response", (), {"content": b"", "headers": {}})()
+
+
+@dataclass
+class _RecordingAsyncHttp:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def request(self, *args: Any, **kwargs: Any):
+        self.calls.append((args, kwargs))
+        return type("Response", (), {"content": b"", "headers": {}})()
+
+
+class _StubSessionsClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self._batch_requests = 0
+
+    def open_online_session(self, payload, *, access_token=None, upo_v43=False):
+        self.calls.append(("open_online", payload, access_token, upo_v43))
+        return _open_online_session_response()
+
+    def send_online_invoice(self, reference_number, request_payload, *, access_token=None):
+        self.calls.append(("send_online", reference_number, request_payload, access_token))
+        return m.SendInvoiceResponse.from_dict({"referenceNumber": "INV-1"})
+
+    def close_online_session(self, reference_number, access_token=None):
+        self.calls.append(("close_online", reference_number, access_token))
+
+    def open_batch_session(self, payload, *, access_token=None, upo_v43=False):
+        self.calls.append(("open_batch", payload, access_token, upo_v43))
+        self._batch_requests = len(payload.batch_file.file_parts)
+        return _open_batch_session_response(self._batch_requests)
+
+    def close_batch_session(self, reference_number, access_token=None):
+        self.calls.append(("close_batch", reference_number, access_token))
+
+    def get_session_status(self, reference_number, access_token=None):
+        self.calls.append(("status", reference_number, access_token))
+        return _status_payload()
+
+    def get_session_invoices(
+        self, reference_number, *, page_size=None, continuation_token=None, access_token=None
+    ):
+        self.calls.append(("list", reference_number, page_size, continuation_token, access_token))
+        return m.SessionInvoicesResponse.from_dict({"invoices": []})
+
+    def get_session_failed_invoices(
+        self, reference_number, *, page_size=None, continuation_token=None, access_token=None
+    ):
+        self.calls.append(
+            ("list_failed", reference_number, page_size, continuation_token, access_token)
+        )
+        return m.SessionInvoicesResponse.from_dict({"invoices": []})
+
+    def get_session_invoice_status(
+        self, reference_number, invoice_reference_number, *, access_token=None
+    ):
+        self.calls.append(
+            ("invoice_status", reference_number, invoice_reference_number, access_token)
+        )
+        return _invoice_status_payload()
+
+    def get_session_invoice_upo_by_ref(
+        self, reference_number, invoice_reference_number, *, access_token=None
+    ):
+        self.calls.append(
+            ("invoice_upo_ref", reference_number, invoice_reference_number, access_token)
+        )
+        return b"<upo-by-ref/>"
+
+    def get_session_invoice_upo_by_ksef(self, reference_number, ksef_number, *, access_token=None):
+        self.calls.append(("invoice_upo_ksef", reference_number, ksef_number, access_token))
+        return b"<upo-by-ksef/>"
+
+    def get_session_upo(self, reference_number, upo_reference_number, *, access_token=None):
+        self.calls.append(("session_upo", reference_number, upo_reference_number, access_token))
+        return b"<upo-session/>"
+
+
+class _StubAsyncSessionsClient(_StubSessionsClient):
+    async def open_online_session(self, payload, *, access_token=None, upo_v43=False):
+        return super().open_online_session(payload, access_token=access_token, upo_v43=upo_v43)
+
+    async def send_online_invoice(self, reference_number, request_payload, *, access_token=None):
+        return super().send_online_invoice(
+            reference_number,
+            request_payload,
+            access_token=access_token,
+        )
+
+    async def close_online_session(self, reference_number, access_token=None):
+        super().close_online_session(reference_number, access_token=access_token)
+
+    async def open_batch_session(self, payload, *, access_token=None, upo_v43=False):
+        return super().open_batch_session(payload, access_token=access_token, upo_v43=upo_v43)
+
+    async def close_batch_session(self, reference_number, access_token=None):
+        super().close_batch_session(reference_number, access_token=access_token)
+
+    async def get_session_status(self, reference_number, access_token=None):
+        return super().get_session_status(reference_number, access_token=access_token)
+
+    async def get_session_invoices(
+        self, reference_number, *, page_size=None, continuation_token=None, access_token=None
+    ):
+        return super().get_session_invoices(
+            reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=access_token,
+        )
+
+    async def get_session_failed_invoices(
+        self, reference_number, *, page_size=None, continuation_token=None, access_token=None
+    ):
+        return super().get_session_failed_invoices(
+            reference_number,
+            page_size=page_size,
+            continuation_token=continuation_token,
+            access_token=access_token,
+        )
+
+    async def get_session_invoice_status(
+        self, reference_number, invoice_reference_number, *, access_token=None
+    ):
+        return super().get_session_invoice_status(
+            reference_number,
+            invoice_reference_number,
+            access_token=access_token,
+        )
+
+    async def get_session_invoice_upo_by_ref(
+        self, reference_number, invoice_reference_number, *, access_token=None
+    ):
+        return super().get_session_invoice_upo_by_ref(
+            reference_number,
+            invoice_reference_number,
+            access_token=access_token,
+        )
+
+    async def get_session_invoice_upo_by_ksef(
+        self, reference_number, ksef_number, *, access_token=None
+    ):
+        return super().get_session_invoice_upo_by_ksef(
+            reference_number,
+            ksef_number,
+            access_token=access_token,
+        )
+
+    async def get_session_upo(self, reference_number, upo_reference_number, *, access_token=None):
+        return super().get_session_upo(
+            reference_number,
+            upo_reference_number,
+            access_token=access_token,
+        )
+
+
+def test_online_session_state_roundtrip_and_validation() -> None:
+    state = OnlineSessionState(
+        reference_number="SES-1",
+        form_code=_form_code(),
+        valid_until="2026-04-01T12:30:00Z",
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+        upo_v43=True,
+    )
+    restored = OnlineSessionState.from_dict(state.to_dict())
+    assert restored == state
+    assert OnlineSessionState.from_json(state.to_json()) == state
+
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(state.to_dict() | {"schema_version": 2})
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(state.to_dict() | {"kind": "batch"})
+    with pytest.raises(ValueError):
+        OnlineSessionState.from_dict(state.to_dict() | {"symmetric_key_base64": "???"})
+
+
+def test_batch_session_state_roundtrip_and_validation() -> None:
+    batch_file = m.BatchFileInfo.from_dict(
+        {
+            "fileSize": 10,
+            "fileHash": "hash",
+            "fileParts": [{"ordinalNumber": 1, "fileSize": 10, "fileHash": "hash-part"}],
+        }
+    )
+    request = m.PartUploadRequest.from_dict(
+        {
+            "ordinalNumber": 1,
+            "url": "https://upload/1",
+            "method": "PUT",
+            "headers": {"x": "y"},
+        }
+    )
+    state = BatchSessionState(
+        reference_number="SES-BATCH",
+        form_code=_form_code(),
+        batch_file=batch_file,
+        part_upload_requests=[request],
+        symmetric_key_base64="AQID",
+        iv_base64="BAUG",
+        upo_v43=False,
+        offline_mode=True,
+    )
+    restored = BatchSessionState.from_dict(state.to_dict())
+    assert restored == state
+    assert BatchSessionState.from_json(state.to_json()) == state
+
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(state.to_dict() | {"kind": "online"})
+    with pytest.raises(ValueError):
+        BatchSessionState.from_dict(state.to_dict() | {"iv_base64": "###"})
+
+
+def test_online_workflow_returns_handle_and_resume_supports_status_methods() -> None:
+    sessions = _StubSessionsClient()
+    workflow = OnlineSessionWorkflow(sessions)
+    rsa_cert = generate_rsa_cert()
+
+    session = workflow.open_session(
+        form_code=_form_code(),
+        public_certificate=rsa_cert.certificate_pem,
+        access_token="token",
+        upo_v43=True,
+    )
+
+    assert isinstance(session, OnlineSessionHandle)
+    assert session.session_reference_number == "SES-ONLINE-1"
+    assert session.get_status(access_token="override").status.code == 200
+
+    resumed = workflow.resume_session(session.get_state(), access_token="token")
+    assert resumed.get_invoice_status("INV-1").reference_number == "INV-1"
+    assert resumed.get_invoice_upo_by_ref("INV-1") == b"<upo-by-ref/>"
+    assert resumed.get_invoice_upo_by_ksef("KSEF-1") == b"<upo-by-ksef/>"
+    assert resumed.get_upo("UPO-1") == b"<upo-session/>"
+    resumed.close()
+
+
+def test_batch_workflow_resume_validates_zip_and_upload_progress() -> None:
+    sessions = _StubSessionsClient()
+    http = _RecordingHttp()
+    workflow = BatchSessionWorkflow(sessions, http)
+    rsa_cert = generate_rsa_cert()
+    zip_bytes = build_zip({"a.xml": b"<a/>", "b.xml": b"<b/>"})
+
+    session = workflow.open_session(
+        form_code=_form_code(),
+        zip_bytes=zip_bytes,
+        public_certificate=rsa_cert.certificate_pem,
+        access_token="token",
+        upo_v43=True,
+    )
+
+    uploaded_ordinals: list[int] = []
+    session.upload_parts(
+        parallelism=2,
+        progress_callback=lambda ordinal: uploaded_ordinals.append(ordinal),
+    )
+    assert uploaded_ordinals == [1]
+    assert len(http.calls) == 1
+
+    resumed = workflow.resume_session(
+        session.get_state(),
+        zip_bytes=zip_bytes,
+        access_token="token",
+    )
+    resumed.upload_parts(progress_callback=lambda ordinal: uploaded_ordinals.append(ordinal))
+    assert uploaded_ordinals[-1:] == [1]
+    resumed.close()
+
+    with pytest.raises(ValueError):
+        workflow.resume_session(
+            session.get_state(),
+            zip_bytes=build_zip({"changed.xml": b"<x/>"}),
+            access_token="token",
+        )
+
+
+def test_async_online_workflow_resume_supports_handle_methods() -> None:
+    async def _run() -> None:
+        sessions = _StubAsyncSessionsClient()
+        workflow = AsyncOnlineSessionWorkflow(sessions)
+        rsa_cert = generate_rsa_cert()
+
+        session = await workflow.open_session(
+            form_code=_form_code(),
+            public_certificate=rsa_cert.certificate_pem,
+            access_token="token",
+        )
+        await session.send_invoice(b"<faktura/>")
+        resumed = workflow.resume_session(session.get_state(), access_token="token")
+        status = await resumed.get_status()
+        assert status.status.code == 200
+        await resumed.close()
+
+    asyncio.run(_run())
+
+
+def test_async_batch_upload_helper_supports_skip_and_progress() -> None:
+    async def _run() -> None:
+        http = _RecordingAsyncHttp()
+        helper = AsyncBatchUploadHelper(http)
+        requests = [
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 1,
+                    "url": "https://upload/1",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            ),
+            m.PartUploadRequest.from_dict(
+                {
+                    "ordinalNumber": 2,
+                    "url": "https://upload/2",
+                    "method": "PUT",
+                    "headers": {},
+                }
+            ),
+        ]
+        seen: list[int] = []
+
+        await helper.upload_parts(
+            requests,
+            [(1, b"a"), (2, b"b")],
+            skip_ordinals={1},
+            progress_callback=lambda ordinal: seen.append(ordinal),
+        )
+
+        assert seen == [2]
+        assert len(http.calls) == 1
+
+    asyncio.run(_run())
+
+
+def test_batch_upload_helper_progress_callback_runs_after_success() -> None:
+    http = _RecordingHttp()
+    helper = BatchUploadHelper(http)
+    request = m.PartUploadRequest.from_dict(
+        {
+            "ordinalNumber": 1,
+            "url": "https://upload/1",
+            "method": "PUT",
+            "headers": {},
+        }
+    )
+    seen: list[int] = []
+
+    helper.upload_parts(
+        [request],
+        [b"payload"],
+        progress_callback=lambda ordinal: seen.append(ordinal),
+    )
+
+    assert seen == [1]

--- a/tests/test_services_workflows.py
+++ b/tests/test_services_workflows.py
@@ -211,49 +211,101 @@ class StubAsyncAuthClient:
 
 
 class StubSessionsClient:
-    def __init__(self):
-        self.calls = []
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
 
-    def open_online_session(self, payload, access_token, upo_v43=False):
+    def open_online_session(
+        self,
+        payload: m.OpenOnlineSessionRequest,
+        *,
+        access_token: str | None = None,
+        upo_v43: bool = False,
+    ) -> m.OpenOnlineSessionResponse:
         self.calls.append(("open_online", payload, access_token, upo_v43))
         return _open_online_session_response()
 
-    def send_online_invoice(self, ref, payload, access_token):
-        self.calls.append(("send", ref, payload))
+    def send_online_invoice(
+        self,
+        reference_number: str,
+        request_payload: m.SendInvoiceRequest,
+        *,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse:
+        self.calls.append(("send", reference_number, request_payload, access_token))
         return _send_invoice_response()
 
-    def close_online_session(self, ref, access_token):
-        self.calls.append(("close", ref))
+    def close_online_session(
+        self,
+        reference_number: str,
+        access_token: str | None = None,
+    ) -> None:
+        self.calls.append(("close", reference_number, access_token))
 
-    def open_batch_session(self, payload, access_token, upo_v43=False):
+    def open_batch_session(
+        self,
+        payload: m.OpenBatchSessionRequest,
+        *,
+        access_token: str | None = None,
+        upo_v43: bool = False,
+    ) -> m.OpenBatchSessionResponse:
         self.calls.append(("open_batch", payload, access_token, upo_v43))
         return _open_batch_session_response()
 
-    def close_batch_session(self, ref, access_token):
-        self.calls.append(("close_batch", ref))
+    def close_batch_session(
+        self,
+        reference_number: str,
+        access_token: str | None = None,
+    ) -> None:
+        self.calls.append(("close_batch", reference_number, access_token))
 
 
 class StubAsyncSessionsClient:
-    def __init__(self):
-        self.calls = []
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
 
-    async def open_online_session(self, payload, access_token, upo_v43=False):
+    async def open_online_session(
+        self,
+        payload: m.OpenOnlineSessionRequest,
+        *,
+        access_token: str | None = None,
+        upo_v43: bool = False,
+    ) -> m.OpenOnlineSessionResponse:
         self.calls.append(("open_online", payload, access_token, upo_v43))
         return _open_online_session_response()
 
-    async def send_online_invoice(self, ref, payload, access_token):
-        self.calls.append(("send", ref, payload))
+    async def send_online_invoice(
+        self,
+        reference_number: str,
+        request_payload: m.SendInvoiceRequest,
+        *,
+        access_token: str | None = None,
+    ) -> m.SendInvoiceResponse:
+        self.calls.append(("send", reference_number, request_payload, access_token))
         return _send_invoice_response()
 
-    async def close_online_session(self, ref, access_token):
-        self.calls.append(("close", ref))
+    async def close_online_session(
+        self,
+        reference_number: str,
+        access_token: str | None = None,
+    ) -> None:
+        self.calls.append(("close", reference_number, access_token))
 
-    async def open_batch_session(self, payload, access_token, upo_v43=False):
+    async def open_batch_session(
+        self,
+        payload: m.OpenBatchSessionRequest,
+        *,
+        access_token: str | None = None,
+        upo_v43: bool = False,
+    ) -> m.OpenBatchSessionResponse:
         self.calls.append(("open_batch", payload, access_token, upo_v43))
         return _open_batch_session_response()
 
-    async def close_batch_session(self, ref, access_token):
-        self.calls.append(("close_batch", ref))
+    async def close_batch_session(
+        self,
+        reference_number: str,
+        access_token: str | None = None,
+    ) -> None:
+        self.calls.append(("close_batch", reference_number, access_token))
 
 
 class WorkflowsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add resumable online and batch session state objects with JSON serialization in the SDK
- add CLI session checkpoint storage and `ksef session ...` commands for open/send/upload/close/export/import/drop
- document the new resume flows and add sync/async, CLI, and smoke coverage

## Security
- session JSON state does not include `access_token`
- CLI checkpoints do not include tokens or invoice payloads
- CLI token storage stays in keyring or the existing secured fallback store

## Validation
- `python tools/lint.py --strict`
- `pytest tests -q`