### PR TITLE
fix(cli): harden resumable session recovery paths

### DIFF
--- a/src/ksef_client/cli/sdk/session_ops.py
+++ b/src/ksef_client/cli/sdk/session_ops.py
@@ -106,6 +106,21 @@ def _require_batch_checkpoint(profile: str, session_id: str) -> BatchSessionChec
     return checkpoint
 
 
+def _ensure_checkpoint_not_closed(
+    checkpoint: SessionCheckpoint,
+    *,
+    command_name: str,
+    next_step: str,
+) -> None:
+    if checkpoint.stage != "closed":
+        return
+    raise CliError(
+        f"Session checkpoint '{checkpoint.id}' is already closed.",
+        ExitCode.VALIDATION_ERROR,
+        f"Open a new session checkpoint before running `{command_name}`. {next_step}",
+    )
+
+
 def _checkpoint_summary(checkpoint: SessionCheckpoint) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "id": checkpoint.id,
@@ -217,6 +232,11 @@ def send_online_session_invoice(
     save_upo_overwrite: bool = False,
 ) -> dict[str, Any]:
     checkpoint = _require_online_checkpoint(profile, session_id)
+    _ensure_checkpoint_not_closed(
+        checkpoint,
+        command_name="ksef session online send",
+        next_step="Use `ksef session online open --id <NEW_ID>` first.",
+    )
     access_token = adapters._require_access_token(profile)
     if save_upo and not wait_upo:
         raise CliError(
@@ -308,6 +328,14 @@ def close_online_session(
     session_id: str,
 ) -> dict[str, Any]:
     checkpoint = _require_online_checkpoint(profile, session_id)
+    _ensure_checkpoint_not_closed(
+        checkpoint,
+        command_name="ksef session online close",
+        next_step=(
+            "Use `ksef session online open --id <NEW_ID>` "
+            "if you need a new resumable session."
+        ),
+    )
     access_token = adapters._require_access_token(profile)
     with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
         workflow = OnlineSessionWorkflow(client.sessions)
@@ -369,6 +397,11 @@ def upload_batch_session(
     parallelism: int,
 ) -> dict[str, Any]:
     checkpoint = _require_batch_checkpoint(profile, session_id)
+    _ensure_checkpoint_not_closed(
+        checkpoint,
+        command_name="ksef session batch upload",
+        next_step="Use `ksef session batch open --id <NEW_ID>` to start a new batch session.",
+    )
     access_token = adapters._require_access_token(profile)
     if parallelism <= 0:
         raise CliError(
@@ -435,7 +468,6 @@ def close_batch_session(
     save_upo_overwrite: bool = False,
 ) -> dict[str, Any]:
     checkpoint = _require_batch_checkpoint(profile, session_id)
-    access_token = adapters._require_access_token(profile)
     if save_upo and not wait_upo:
         raise CliError(
             "Option --save-upo requires --wait-upo.",
@@ -445,15 +477,20 @@ def close_batch_session(
     if wait_status or wait_upo:
         adapters._validate_polling_options(poll_interval, max_attempts)
 
+    if checkpoint.stage == "closed" and not (wait_status or wait_upo):
+        return _checkpoint_summary(checkpoint)
+
+    access_token = adapters._require_access_token(profile)
     with adapters.create_client(checkpoint.base_url, access_token=access_token) as client:
-        session = BatchSessionHandle.from_state(
-            checkpoint.session_state,
-            sessions_client=client.sessions,
-            uploader=BatchUploadHelper(client.http_client),
-            access_token=access_token,
-        )
-        session.close(access_token=access_token)
-        checkpoint = cast(BatchSessionCheckpoint, update_checkpoint(checkpoint, stage="closed"))
+        if checkpoint.stage != "closed":
+            session = BatchSessionHandle.from_state(
+                checkpoint.session_state,
+                sessions_client=client.sessions,
+                uploader=BatchUploadHelper(client.http_client),
+                access_token=access_token,
+            )
+            session.close(access_token=access_token)
+            checkpoint = cast(BatchSessionCheckpoint, update_checkpoint(checkpoint, stage="closed"))
 
         result: dict[str, Any] = _checkpoint_summary(checkpoint)
         if wait_status or wait_upo:

--- a/src/ksef_client/utils/zip_utils.py
+++ b/src/ksef_client/utils/zip_utils.py
@@ -5,13 +5,18 @@ import zipfile
 from pathlib import PurePosixPath
 
 MAX_BATCH_PART_SIZE_BYTES = 100 * 1024 * 1024
+_DETERMINISTIC_ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)
 
 
 def build_zip(files: dict[str, bytes]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for name, content in files.items():
-            zf.writestr(name, content)
+            info = zipfile.ZipInfo(filename=name, date_time=_DETERMINISTIC_ZIP_DATE_TIME)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = 0
+            info.external_attr = 0
+            zf.writestr(info, content)
     return buffer.getvalue()
 
 

--- a/tests/cli/unit/test_session_ops.py
+++ b/tests/cli/unit/test_session_ops.py
@@ -430,6 +430,47 @@ def test_send_online_session_invoice_wait_upo_without_saving_returns_empty_path(
     assert result["upo_path"] == ""
 
 
+def test_send_online_session_invoice_rejects_closed_checkpoint(monkeypatch) -> None:
+    checkpoint = replace(_online_checkpoint(), stage="closed")
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_require_access_token",
+        lambda profile: (_ for _ in ()).throw(AssertionError("token lookup should not run")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        session_ops.send_online_session_invoice(
+            profile="demo",
+            session_id="resume-online",
+            invoice="invoice.xml",
+            wait_status=False,
+            wait_upo=False,
+            poll_interval=1.0,
+            max_attempts=1,
+            save_upo=None,
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "already closed" in exc.value.message
+
+
+def test_close_online_session_rejects_closed_checkpoint(monkeypatch) -> None:
+    checkpoint = replace(_online_checkpoint(), stage="closed")
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_require_access_token",
+        lambda profile: (_ for _ in ()).throw(AssertionError("token lookup should not run")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        session_ops.close_online_session(profile="demo", session_id="resume-online")
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "already closed" in exc.value.message
+
+
 def test_open_batch_session_closes_handle_when_save_fails(monkeypatch) -> None:
     closed: list[str | None] = []
 
@@ -548,6 +589,26 @@ def test_upload_batch_session_validates_parallelism_and_updates_progress(monkeyp
     assert updated[-1].uploaded_ordinals == [1]
 
 
+def test_upload_batch_session_rejects_closed_checkpoint(monkeypatch) -> None:
+    checkpoint = replace(_batch_checkpoint(), stage="closed")
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_require_access_token",
+        lambda profile: (_ for _ in ()).throw(AssertionError("token lookup should not run")),
+    )
+
+    with pytest.raises(CliError) as exc:
+        session_ops.upload_batch_session(
+            profile="demo",
+            session_id="resume-batch",
+            parallelism=1,
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "already closed" in exc.value.message
+
+
 def test_close_batch_session_validates_and_waits(monkeypatch, tmp_path: Path) -> None:
     checkpoint = _batch_checkpoint()
 
@@ -643,6 +704,36 @@ def test_close_batch_session_validates_and_waits(monkeypatch, tmp_path: Path) ->
     assert close_calls == ["token"]
     assert validate_calls == [(0.5, 5)]
     assert updated[-1].last_upo_ref == "UPO-1"
+
+
+def test_close_batch_session_returns_summary_for_closed_checkpoint_without_waits(
+    monkeypatch,
+) -> None:
+    checkpoint = replace(_batch_checkpoint(), stage="closed")
+    monkeypatch.setattr(session_ops, "load_checkpoint", lambda profile, session_id: checkpoint)
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_require_access_token",
+        lambda profile: (_ for _ in ()).throw(AssertionError("token lookup should not run")),
+    )
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "create_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("client should not open")),
+    )
+
+    result = session_ops.close_batch_session(
+        profile="demo",
+        session_id="resume-batch",
+        wait_status=False,
+        wait_upo=False,
+        poll_interval=1.0,
+        max_attempts=1,
+        save_upo=None,
+    )
+
+    assert result["id"] == "resume-batch"
+    assert result["stage"] == "closed"
 
 
 def test_close_batch_session_wait_upo_requires_reference(monkeypatch) -> None:

--- a/tests/test_zip_utils.py
+++ b/tests/test_zip_utils.py
@@ -14,6 +14,16 @@ class ZipUtilsTests(unittest.TestCase):
         self.assertEqual(unzipped["a.txt"], b"hello")
         self.assertEqual(unzipped["b.txt"], b"world")
 
+    def test_build_zip_is_deterministic(self):
+        files = {"a.txt": b"hello", "b.txt": b"world"}
+
+        first = build_zip(files)
+        second = build_zip(files)
+
+        self.assertEqual(first, second)
+        with zipfile.ZipFile(BytesIO(first), "r") as zf:
+            self.assertEqual(zf.getinfo("a.txt").date_time, (1980, 1, 1, 0, 0, 0))
+
     def test_unzip_limits_max_files(self):
         files = {"a.txt": b"hello", "b.txt": b"world"}
         zip_bytes = build_zip(files)


### PR DESCRIPTION
## Summary
- make directory-backed batch ZIP fingerprints deterministic so resume after --dir remains stable
- reject resumed operations against checkpoints already marked as closed
- make session batch close restart-safe when the checkpoint is already closed

## Validation
- python -m pytest -q
- python -m pytest tests/cli/unit/test_session_ops.py tests/cli/smoke/test_cli_session_resume_flow.py tests/test_zip_utils.py -q
