### PR TITLE
Aktualizacja ksef-client-python do KSeF 2.5.0

### DIFF
--- a/.github/workflows/python-e2e.yml
+++ b/.github/workflows/python-e2e.yml
@@ -363,6 +363,7 @@ jobs:
           KSEF_DEMO_XADES_PRIVATE_KEY_PEM_B64: ${{ secrets.KSEF_DEMO_XADES_PRIVATE_KEY_PEM_B64 }}
           KSEF_DEMO_XADES_PRIVATE_KEY_PASSWORD: ${{ secrets.KSEF_DEMO_XADES_PRIVATE_KEY_PASSWORD }}
           KSEF_DEMO_XADES_SUBJECT_IDENTIFIER_TYPE: certificateSubject
+          KSEF_DEMO_XADES_AUTH_REQUEST_SCHEMA_VERSION: "2.0"
         run: |
           python -m pytest -q --maxfail=1 --disable-warnings \
             tests/test_e2e_token_flows.py::test_e2e_demo_environment_full_flow_xades

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -458,7 +458,7 @@ Uwagi:
 - Przy udanym zakonczeniu komenda nadal zamyka sesje; checkpoint sluzy glownie do inspekcji
   oraz odzyskania flow po przerwaniu lub bledzie po zapisaniu checkpointu.
 - `--save-upo-overwrite` pozwala nadpisac istniejacy plik UPO wskazany przez `--save-upo`.
-- Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`; CLI normalizuje historyczne `RR` do `FA_RR`.
+- Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`.
 
 ## `ksef send batch`
 
@@ -489,7 +489,7 @@ Walidacja:
 - Przy udanym zakonczeniu komenda nadal zamyka sesje; checkpoint sluzy glownie do inspekcji
   oraz odzyskania flow po przerwaniu lub bledzie po zapisaniu checkpointu.
 - `--save-upo-overwrite` pozwala nadpisac istniejacy plik UPO wskazany przez `--save-upo`.
-- Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`; CLI normalizuje historyczne `RR` do `FA_RR`.
+- Dla `FA_RR (1)` z `--schema-version 1-1E` uzyj `--form-value FA_RR`.
 
 ## Resumable sessions
 

--- a/docs/services/auth.md
+++ b/docs/services/auth.md
@@ -14,6 +14,7 @@ Najważniejsze parametry:
 - `context_identifier_value`: wartość identyfikatora kontekstu (np. NIP)
 - `subject_identifier_type`: domyślnie `"certificateSubject"`; alternatywnie `"certificateFingerprint"`
 - `authorization_policy_xml`: opcjonalnie fragment XML z polityką (np. allow-list IP)
+- `schema_version`: domyślnie `"2.1"`; można przekazać `"2.0"` dla zgodności wstecznej
 
 ## `encrypt_ksef_token(...) -> str`
 
@@ -36,4 +37,5 @@ Parametry:
 - `challenge`: z `get_challenge()`
 - `context_identifier_type`, `context_identifier_value`: jak wyżej
 - `encrypted_token_base64`: wynik `encrypt_ksef_token(...)`
+- `public_key_id`: opcjonalnie identyfikator klucza KSeF użytego do szyfrowania
 - `authorization_policy`: opcjonalnie polityka (JSON, zależnie od API)

--- a/docs/services/workflows.md
+++ b/docs/services/workflows.md
@@ -47,6 +47,9 @@ Scenariusz:
 5. polling `GET /auth/{referenceNumber}` aż `status.code == 200`
 6. `POST /auth/token/redeem`
 
+Domyślnie używana jest schema `AuthTokenRequest` `2.1`; parametr
+`auth_request_schema_version="2.0"` zachowuje możliwość wygenerowania XML w starszej przestrzeni nazw.
+
 ### `AuthCoordinator.authenticate_with_ksef_token(...) -> AuthResult`
 
 Scenariusz analogiczny, ale z szyfrowaniem wartości `token|timestampMs` certyfikatem KSeF

--- a/docs/workflows/online-session.md
+++ b/docs/workflows/online-session.md
@@ -125,7 +125,7 @@ Zgodność wsteczna:
 
 - `encryption_data` z `open_session()` musi być użyte dla wszystkich faktur wysyłanych w ramach tej sesji; dlatego jest odtwarzane również przy `resume_session()`.
 - `resume_session()` odtwarza tylko stan sesji i materiał kryptograficzny. Statusy faktur wysłanych wcześniej trzeba śledzić osobno przez `invoice_reference`.
-- Dla `FA_RR (1)` w wersji `1-1E` przekazuj `formCode.value="FA_RR"` zamiast `RR`.
+- Dla `FA_RR (1)` w wersji `1-1E` przekazuj `formCode.value="FA_RR"`.
 - Status przetwarzania jest udostępniany asynchronicznie; sprawdzanie statusu odbywa się przez polling.
 - Pobranie UPO:
   - dla faktury: `get_invoice_upo_by_ref()` / `get_invoice_upo_by_ksef()`

--- a/specs/ksef-openapi.snapshot.json
+++ b/specs/ksef-openapi.snapshot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.4",
   "info": {
     "title": "KSeF API TE",
-    "description": "**Wersja API:** 2.4.0 (build 2.4.0-te)<br>\n**Klucze publiczne** Ministerstwa Finansów (dla danego środowiska): [Pobierz klucze](#tag/Certyfikaty-klucza-publicznego)<br>\n**Historia zmian:** [Changelog](https://github.com/CIRFMF/ksef-docs/blob/main/api-changelog.md)<br>\n**Rozszerzona dokumentacja API:** [ksef-docs](https://github.com/CIRFMF/ksef-docs/tree/main)\n\n**Adres serwera API:**\n- Środowisko TEST: `https://api-test.ksef.mf.gov.pl/v2`\n- [deprecated] Środowisko TEST: `https://ksef-test.mf.gov.pl/api/v2`\n",
+    "description": "**Wersja API:** 2.5.0 (build 2.5.0-te)<br>\n**Klucze publiczne** Ministerstwa Finansów (dla danego środowiska): [Pobierz klucze](#tag/Certyfikaty-klucza-publicznego)<br>\n**Historia zmian:** [Changelog](https://github.com/CIRFMF/ksef-docs/blob/main/api-changelog.md)<br>\n**Rozszerzona dokumentacja API:** [ksef-docs](https://github.com/CIRFMF/ksef-docs/tree/main)\n\n**Adres serwera API:**\n- Środowisko TEST: `https://api-test.ksef.mf.gov.pl/v2`\n- [deprecated] Środowisko TEST: `https://ksef-test.mf.gov.pl/api/v2`\n",
     "version": "v2"
   },
   "servers": [
@@ -18,7 +18,7 @@
           "Aktywne sesje"
         ],
         "summary": "Pobranie listy aktywnych sesji",
-        "description": "Zwraca listę aktywnych sesji uwierzytelnienia.\n\n**Sortowanie:**\n\n- startDate (Desc)\n\n",
+        "description": "Zwraca listę aktywnych sesji uwierzytelnienia.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n\n",
         "parameters": [
           {
             "name": "x-continuation-token",
@@ -38,17 +38,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -102,7 +91,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -151,9 +140,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -169,20 +158,7 @@
           "Aktywne sesje"
         ],
         "summary": "Unieważnienie aktualnej sesji uwierzytelnienia",
-        "description": "Unieważnia sesję powiązaną z tokenem użytym do wywołania tej operacji.\n\nUnieważnienie sesji sprawia, że powiązany z nią refresh token przestaje działać i nie można już za jego pomocą uzyskać kolejnych access tokenów.\n**Aktywne access tokeny działają do czasu minięcia ich termin ważności.**\n\nSposób uwierzytelnienia: `RefreshToken` lub `AccessToken`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Unieważnia sesję powiązaną z tokenem użytym do wywołania tej operacji.\n\nUnieważnienie sesji sprawia, że powiązany z nią refresh token przestaje działać i nie można już za jego pomocą uzyskać kolejnych access tokenów.\n**Aktywne access tokeny działają do czasu minięcia ich termin ważności.**\n\nSposób uwierzytelnienia: `RefreshToken` lub `AccessToken`.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "204": {
             "description": "No Content"
@@ -204,7 +180,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -253,9 +229,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -265,7 +241,7 @@
           "Aktywne sesje"
         ],
         "summary": "Unieważnienie sesji uwierzytelnienia",
-        "description": "Unieważnia sesję o podanym numerze referencyjnym.\n\nUnieważnienie sesji sprawia, że powiązany z nią refresh token przestaje działać i nie można już za jego pomocą uzyskać kolejnych access tokenów.\n**Aktywne access tokeny działają do czasu minięcia ich termin ważności.**",
+        "description": "Unieważnia sesję o podanym numerze referencyjnym.\n\nUnieważnienie sesji sprawia, że powiązany z nią refresh token przestaje działać i nie można już za jego pomocą uzyskać kolejnych access tokenów.\n**Aktywne access tokeny działają do czasu minięcia ich termin ważności.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -274,17 +250,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -309,7 +274,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -358,9 +323,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -370,20 +335,7 @@
           "Certyfikaty"
         ],
         "summary": "Pobranie danych o limitach certyfikatów",
-        "description": "Zwraca informacje o limitach certyfikatów oraz informacje czy użytkownik może zawnioskować o certyfikat KSeF.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca informacje o limitach certyfikatów oraz informacje czy użytkownik może zawnioskować o certyfikat KSeF.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -412,7 +364,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -461,9 +413,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -473,20 +425,7 @@
           "Certyfikaty"
         ],
         "summary": "Pobranie danych do wniosku certyfikacyjnego",
-        "description": "Zwraca dane wymagane do przygotowania wniosku certyfikacyjnego PKCS#10.\n\nDane te są zwracane na podstawie certyfikatu użytego w procesie uwierzytelnienia i identyfikują podmiot, który składa wniosek o certyfikat.\n\n\n> Więcej informacji:\n> - [Pobranie danych do wniosku certyfikacyjnego](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#2-pobranie-danych-do-wniosku-certyfikacyjnego)\n> - [Przygotowanie wniosku](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#3-przygotowanie-csr-certificate-signing-request)",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca dane wymagane do przygotowania wniosku certyfikacyjnego PKCS#10.\n\nDane te są zwracane na podstawie certyfikatu użytego w procesie uwierzytelnienia i identyfikują podmiot, który składa wniosek o certyfikat.\n\n\n> Więcej informacji:\n> - [Pobranie danych do wniosku certyfikacyjnego](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#2-pobranie-danych-do-wniosku-certyfikacyjnego)\n> - [Przygotowanie wniosku](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#3-przygotowanie-csr-certificate-signing-request)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -523,7 +462,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -572,9 +511,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -584,20 +523,7 @@
           "Certyfikaty"
         ],
         "summary": "Wysyłka wniosku certyfikacyjnego",
-        "description": "Przyjmuje wniosek certyfikacyjny i rozpoczyna jego przetwarzanie.\n\nDozwolone typy kluczy prywatnych:\n- RSA (OID: 1.2.840.113549.1.1.1), długość klucza równa 2048 bitów,\n- EC (klucze oparte na krzywych eliptycznych, OID: 1.2.840.10045.2.1), krzywa NIST P-256 (secp256r1)\n\nZalecane jest stosowanie kluczy EC.\n\nDozwolone algorytmy podpisu:\n- RSA PKCS#1 v1.5,\n- RSA PSS,\n- ECDSA (format podpisu zgodny z RFC 3279)\n\nDozwolone funkcje skrótu użyte do podpisu CSR:\n- SHA1,\n- SHA256,\n- SHA384,\n- SHA512\n\n> Więcej informacji:\n> - [Wysłanie wniosku certyfikacyjnego](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#4-wys%C5%82anie-wniosku-certyfikacyjnego)",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Przyjmuje wniosek certyfikacyjny i rozpoczyna jego przetwarzanie.\n\nDozwolone typy kluczy prywatnych:\n- RSA (OID: 1.2.840.113549.1.1.1), długość klucza równa 2048 bitów,\n- EC (klucze oparte na krzywych eliptycznych, OID: 1.2.840.10045.2.1), krzywa NIST P-256 (secp256r1)\n\nZalecane jest stosowanie kluczy EC.\n\nDozwolone algorytmy podpisu:\n- RSA PKCS#1 v1.5,\n- RSA PSS,\n- ECDSA (format podpisu zgodny z RFC 3279)\n\nDozwolone funkcje skrótu użyte do podpisu CSR:\n- SHA1,\n- SHA256,\n- SHA384,\n- SHA512\n\n> Więcej informacji:\n> - [Wysłanie wniosku certyfikacyjnego](https://github.com/CIRFMF/ksef-docs/blob/main/certyfikaty-KSeF.md#4-wys%C5%82anie-wniosku-certyfikacyjnego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "description": "",
           "content": {
@@ -655,7 +581,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -704,9 +630,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -716,7 +642,7 @@
           "Certyfikaty"
         ],
         "summary": "Pobranie statusu przetwarzania wniosku certyfikacyjnego\n\nStatus wniosku jest dostępny przez 30 dni.",
-        "description": "Zwraca informacje o statusie wniosku certyfikacyjnego.",
+        "description": "Zwraca informacje o statusie wniosku certyfikacyjnego.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -725,17 +651,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -792,7 +707,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -841,9 +756,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -853,20 +768,7 @@
           "Certyfikaty"
         ],
         "summary": "Pobranie certyfikatu lub listy certyfikatów",
-        "description": "Zwraca certyfikaty o podanych numerach seryjnych w formacie DER zakodowanym w Base64.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca certyfikaty o podanych numerach seryjnych w formacie DER zakodowanym w Base64.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "description": "",
           "content": {
@@ -928,7 +830,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -977,9 +879,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -989,7 +891,7 @@
           "Certyfikaty"
         ],
         "summary": "Unieważnienie certyfikatu",
-        "description": "Unieważnia certyfikat o podanym numerze seryjnym. Operacja nie jest dostępna dla podmiotu uwierzytelnionego tokenem KSeF.\n\nPodmiot może unieważnić wyłącznie certyfikat wygenerowany na jego identyfikator uwierzytelnienia  \nlub na identyfikator powiązany w ramach powiązania NIP–PESEL.",
+        "description": "Unieważnia certyfikat o podanym numerze seryjnym. Operacja nie jest dostępna dla podmiotu uwierzytelnionego tokenem KSeF.\n\nPodmiot może unieważnić wyłącznie certyfikat wygenerowany na jego identyfikator uwierzytelnienia  \nlub na identyfikator powiązany w ramach powiązania NIP–PESEL.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "certificateSerialNumber",
@@ -997,17 +899,9 @@
             "description": "Numer seryjny certyfikatu (w formacie szesnastkowym).",
             "required": true,
             "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
+              "maxLength": 16,
+              "minLength": 16,
+              "pattern": "^[0-9A-F]{16}$",
               "type": "string"
             }
           }
@@ -1047,7 +941,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -1096,9 +990,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -1108,7 +1002,7 @@
           "Certyfikaty"
         ],
         "summary": "Pobranie listy metadanych certyfikatów",
-        "description": "Zwraca listę certyfikatów spełniających podane kryteria wyszukiwania.\nW przypadku braku podania kryteriów wyszukiwania zwrócona zostanie nieprzefiltrowana lista.\n\n**Sortowanie:**\n\n- requestDate (Desc)\n\n",
+        "description": "Zwraca listę certyfikatów spełniających podane kryteria wyszukiwania.\nW przypadku braku podania kryteriów wyszukiwania zwrócona zostanie nieprzefiltrowana lista.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- requestDate (Desc)\n\n",
         "parameters": [
           {
             "name": "pageSize",
@@ -1131,17 +1025,6 @@
               "type": "integer",
               "format": "int32",
               "default": 0
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -1211,7 +1094,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -1260,9 +1143,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -1278,20 +1161,7 @@
           "Certyfikaty klucza publicznego"
         ],
         "summary": "Pobranie certyfikatów",
-        "description": "Zwraca informacje o kluczach publicznych używanych do szyfrowania danych przesyłanych do systemu KSeF.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca informacje o kluczach publicznych używanych do szyfrowania danych przesyłanych do systemu KSeF.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -1306,10 +1176,21 @@
                 "example": [
                   {
                     "certificate": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwocTwdNgt2+PXJ2fcB7k1kn5eFUTXBeep9pH...",
+                    "certificateId": "35k6IVMTxUPZKQdg4Fbx36T5/v3aoJK5hIY7sS7mt3U=",
+                    "publicKeyId": "QIoAK/Yc3s27Z4t3SZY4Mhp8JNLH7Vl4N3lNlJAEig8=",
                     "validFrom": "2024-07-11T12:23:56.0154302+00:00",
                     "validTo": "2028-07-11T12:23:56.0154302+00:00",
                     "usage": [
-                      "KsefTokenEncryption",
+                      "KsefTokenEncryption"
+                    ]
+                  },
+                  {
+                    "certificate": "MIIGWDCCBECgAwIBAgIQe4NvS/i3yyDCcnaXiiC6BTANBgkqhkiG9w0BAQsFADBOMQswCQYDVQQGEwJa...",
+                    "certificateId": "sivtxip78UcnFLzXVsAz2FE1XIpLpySOZsn/f99fDmI=",
+                    "publicKeyId": "tmtCidSRzR4fvNpLU5hMOM6FzamxJf0BBR8IkXIAwsY=",
+                    "validFrom": "2024-07-11T12:23:56.0154302+00:00",
+                    "validTo": "2028-07-11T12:23:56.0154302+00:00",
+                    "usage": [
                       "SymmetricKeyEncryption"
                     ]
                   }
@@ -1368,20 +1249,7 @@
           "Dane testowe"
         ],
         "summary": "Utworzenie podmiotu",
-        "description": "Tworzenie nowego podmiotu testowego. W przypadku grupy VAT i JST istnieje możliwość stworzenia jednostek podrzędnych. W wyniku takiego działania w systemie powstanie powiązanie między tymi podmiotami.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Tworzenie nowego podmiotu testowego. W przypadku grupy VAT i JST istnieje możliwość stworzenia jednostek podrzędnych. W wyniku takiego działania w systemie powstanie powiązanie między tymi podmiotami.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1461,20 +1329,7 @@
           "Dane testowe"
         ],
         "summary": "Usunięcie podmiotu",
-        "description": "Usuwanie podmiotu testowego. W przypadku grupy VAT i JST usunięte zostaną również jednostki podrzędne.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Usuwanie podmiotu testowego. W przypadku grupy VAT i JST usunięte zostaną również jednostki podrzędne.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1549,20 +1404,7 @@
           "Dane testowe"
         ],
         "summary": "Utworzenie osoby fizycznej",
-        "description": "Tworzenie nowej osoby fizycznej, której system nadaje uprawnienia właścicielskie. Można również określić, czy osoba ta jest komornikiem – wówczas otrzyma odpowiednie uprawnienie egzekucyjne.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Tworzenie nowej osoby fizycznej, której system nadaje uprawnienia właścicielskie. Można również określić, czy osoba ta jest komornikiem – wówczas otrzyma odpowiednie uprawnienie egzekucyjne.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1645,20 +1487,7 @@
           "Dane testowe"
         ],
         "summary": "Usunięcie osoby fizycznej",
-        "description": "Usuwanie testowej osoby fizycznej. System automatycznie odbierze jej wszystkie uprawnienia.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Usuwanie testowej osoby fizycznej. System automatycznie odbierze jej wszystkie uprawnienia.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1733,20 +1562,7 @@
           "Dane testowe"
         ],
         "summary": "Nadanie uprawnień testowemu podmiotowi/osobie fizycznej",
-        "description": "Nadawanie uprawnień testowemu podmiotowi lub osobie fizycznej, a także w ich kontekście.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Nadawanie uprawnień testowemu podmiotowi lub osobie fizycznej, a także w ich kontekście.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1836,20 +1652,7 @@
           "Dane testowe"
         ],
         "summary": "Odebranie uprawnień testowemu podmiotowi/osobie fizycznej",
-        "description": "Odbieranie uprawnień nadanych testowemu podmiotowi lub osobie fizycznej, a także w ich kontekście.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Odbieranie uprawnień nadanych testowemu podmiotowi lub osobie fizycznej, a także w ich kontekście.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1932,20 +1735,7 @@
           "Dane testowe"
         ],
         "summary": "Umożliwienie wysyłania faktur z załącznikiem",
-        "description": "Dodaje możliwość wysyłania faktur z załącznikiem przez wskazany podmiot",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Dodaje możliwość wysyłania faktur z załącznikiem przez wskazany podmiot\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2020,20 +1810,7 @@
           "Dane testowe"
         ],
         "summary": "Odebranie możliwości wysyłania faktur z załącznikiem",
-        "description": "Odbiera możliwość wysyłania faktur z załącznikiem przez wskazany podmiot",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Odbiera możliwość wysyłania faktur z załącznikiem przez wskazany podmiot\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2108,20 +1885,7 @@
           "Dane testowe"
         ],
         "summary": "Zablokowanie kontekstu",
-        "description": "Blokuje możliwość uwierzytelniania dla wskazanego kontekstu. Uwierzytelnianie zakończy się błędem 480.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Blokuje możliwość uwierzytelniania dla wskazanego kontekstu. Uwierzytelnianie zakończy się błędem 480.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2156,7 +1920,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2180,9 +1944,9 @@
           }
         },
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2192,20 +1956,7 @@
           "Dane testowe"
         ],
         "summary": "Odblokowanie kontekstu",
-        "description": "Odblokowuje możliwość uwierzytelniania dla wskazanego kontekstu.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Odblokowuje możliwość uwierzytelniania dla wskazanego kontekstu.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2240,7 +1991,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2264,9 +2015,9 @@
           }
         },
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2276,20 +2027,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Pobranie limitów dla bieżącego kontekstu",
-        "description": "Zwraca wartości aktualnie obowiązujących limitów dla bieżącego kontekstu.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca wartości aktualnie obowiązujących limitów dla bieżącego kontekstu.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -2330,7 +2068,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2379,9 +2117,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2391,20 +2129,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Pobranie limitów dla bieżącego podmiotu",
-        "description": "Zwraca wartości aktualnie obowiązujących limitów dla bieżącego podmiotu.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca wartości aktualnie obowiązujących limitów dla bieżącego podmiotu.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -2441,7 +2166,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2490,9 +2215,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2502,20 +2227,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Pobranie aktualnie obowiązujących limitów API",
-        "description": "Zwraca wartości aktualnie obowiązujących limitów ilości żądań przesyłanych do API.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca wartości aktualnie obowiązujących limitów ilości żądań przesyłanych do API.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -2526,64 +2238,64 @@
                 },
                 "example": {
                   "onlineSession": {
-                    "perSecond": 100,
-                    "perMinute": 300,
-                    "perHour": 1200
+                    "perSecond": 10,
+                    "perMinute": 30,
+                    "perHour": 120
                   },
                   "batchSession": {
-                    "perSecond": 100,
-                    "perMinute": 200,
-                    "perHour": 600
+                    "perSecond": 10,
+                    "perMinute": 20,
+                    "perHour": 60
                   },
                   "invoiceSend": {
-                    "perSecond": 100,
-                    "perMinute": 300,
-                    "perHour": 1800
+                    "perSecond": 10,
+                    "perMinute": 30,
+                    "perHour": 180
                   },
                   "invoiceStatus": {
-                    "perSecond": 300,
-                    "perMinute": 1200,
-                    "perHour": 12000
+                    "perSecond": 30,
+                    "perMinute": 120,
+                    "perHour": 1200
                   },
                   "sessionList": {
-                    "perSecond": 50,
-                    "perMinute": 100,
-                    "perHour": 600
+                    "perSecond": 5,
+                    "perMinute": 10,
+                    "perHour": 60
                   },
                   "sessionInvoiceList": {
-                    "perSecond": 100,
-                    "perMinute": 200,
-                    "perHour": 2000
+                    "perSecond": 10,
+                    "perMinute": 20,
+                    "perHour": 200
                   },
                   "sessionMisc": {
-                    "perSecond": 100,
-                    "perMinute": 1200,
-                    "perHour": 12000
+                    "perSecond": 10,
+                    "perMinute": 120,
+                    "perHour": 1200
                   },
                   "invoiceMetadata": {
-                    "perSecond": 80,
-                    "perMinute": 160,
-                    "perHour": 200
+                    "perSecond": 8,
+                    "perMinute": 16,
+                    "perHour": 20
                   },
                   "invoiceExport": {
-                    "perSecond": 80,
-                    "perMinute": 160,
-                    "perHour": 200
+                    "perSecond": 8,
+                    "perMinute": 16,
+                    "perHour": 20
                   },
                   "invoiceExportStatus": {
-                    "perSecond": 100,
-                    "perMinute": 600,
-                    "perHour": 6000
+                    "perSecond": 10,
+                    "perMinute": 60,
+                    "perHour": 600
                   },
                   "invoiceDownload": {
-                    "perSecond": 80,
-                    "perMinute": 160,
-                    "perHour": 640
+                    "perSecond": 8,
+                    "perMinute": 16,
+                    "perHour": 64
                   },
                   "other": {
-                    "perSecond": 100,
-                    "perMinute": 300,
-                    "perHour": 1200
+                    "perSecond": 10,
+                    "perMinute": 30,
+                    "perHour": 120
                   }
                 }
               }
@@ -2606,7 +2318,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2655,9 +2367,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2667,20 +2379,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Zmiana limitów sesji dla bieżącego kontekstu",
-        "description": "Zmienia wartości aktualnie obowiązujących limitów sesji dla bieżącego kontekstu. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zmienia wartości aktualnie obowiązujących limitów sesji dla bieżącego kontekstu. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2719,7 +2418,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2768,9 +2467,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       },
       "delete": {
@@ -2778,20 +2477,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Przywrócenie domyślnych wartości limitów sesji dla bieżącego kontekstu",
-        "description": "Przywraca wartości aktualnie obowiązujących limitów sesji dla bieżącego kontekstu do wartości domyślnych. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Przywraca wartości aktualnie obowiązujących limitów sesji dla bieżącego kontekstu do wartości domyślnych. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK"
@@ -2813,7 +2499,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2862,9 +2548,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -2874,20 +2560,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Zmiana limitów certyfikatów dla bieżącego podmiotu",
-        "description": "Zmienia wartości aktualnie obowiązujących limitów certyfikatów dla bieżącego podmiotu. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zmienia wartości aktualnie obowiązujących limitów certyfikatów dla bieżącego podmiotu. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2922,7 +2595,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -2971,9 +2644,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       },
       "delete": {
@@ -2981,20 +2654,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Przywrócenie domyślnych wartości limitów certyfikatów dla bieżącego podmiotu",
-        "description": "Przywraca wartości aktualnie obowiązujących limitów certyfikatów dla bieżącego podmiotu do wartości domyślnych. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Przywraca wartości aktualnie obowiązujących limitów certyfikatów dla bieżącego podmiotu do wartości domyślnych. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK"
@@ -3016,7 +2676,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3065,9 +2725,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -3077,20 +2737,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Zmiana limitów API dla bieżącego kontekstu",
-        "description": "Zmienia wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zmienia wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3128,7 +2775,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3177,9 +2824,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       },
       "delete": {
@@ -3187,20 +2834,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Przywrócenie domyślnych wartości limitów API dla bieżącego kontekstu",
-        "description": "Przywraca wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu do wartości domyślnych. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Przywraca wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu do wartości domyślnych. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK"
@@ -3222,7 +2856,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3271,9 +2905,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -3283,20 +2917,7 @@
           "Limity i ograniczenia"
         ],
         "summary": "Zmiana limitów API dla bieżącego kontekstu na wartości produkcyjne",
-        "description": "Zmienia wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu na wartości takie jakie będą na środowisku produkcyjnym. **Tylko na środowiskach testowych.**",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zmienia wartości aktualnie obowiązujących limitów żądań przesyłanych do API dla bieżącego kontekstu na wartości takie jakie będą na środowisku produkcyjnym. **Tylko na środowiskach testowych.**\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK"
@@ -3318,7 +2939,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3367,9 +2988,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -3379,20 +3000,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie osobom fizycznym uprawnień do pracy w KSeF",
-        "description": "Metoda pozwala na nadanie osobie wskazanej w żądaniu uprawnień do pracy w KSeF  \nw kontekście bieżącym.\n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur,  \n- **InvoiceRead** – przeglądanie faktur,  \n- **CredentialsManage** – zarządzanie uprawnieniami,  \n- **CredentialsRead** – przeglądanie uprawnień,  \n- **Introspection** – przeglądanie historii sesji i generowanie UPO,  \n- **SubunitManage** – zarządzanie jednostkami podrzędnymi,  \n- **EnforcementOperations** – wykonywanie operacji egzekucyjnych.\n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.  \nUprawnienie **EnforcementOperations** może być nadane wyłącznie wtedy,  \ngdy podmiot kontekstu ma rolę **EnforcementAuthority** (organ egzekucyjny)  \nlub **CourtBailiff** (komornik sądowy).\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadawanie-uprawnie%C5%84-osobom-fizycznym-do-pracy-w-ksef)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie osobie wskazanej w żądaniu uprawnień do pracy w KSeF  \nw kontekście bieżącym.\n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur,  \n- **InvoiceRead** – przeglądanie faktur,  \n- **CredentialsManage** – zarządzanie uprawnieniami,  \n- **CredentialsRead** – przeglądanie uprawnień,  \n- **Introspection** – przeglądanie historii sesji i generowanie UPO,  \n- **SubunitManage** – zarządzanie jednostkami podrzędnymi,  \n- **EnforcementOperations** – wykonywanie operacji egzekucyjnych.\n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.  \nUprawnienie **EnforcementOperations** może być nadane wyłącznie wtedy,  \ngdy podmiot kontekstu ma rolę **EnforcementAuthority** (organ egzekucyjny)  \nlub **CourtBailiff** (komornik sądowy).\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadawanie-uprawnie%C5%84-osobom-fizycznym-do-pracy-w-ksef)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3463,7 +3071,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3512,9 +3120,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -3527,20 +3135,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie podmiotom uprawnień do obsługi faktur",
-        "description": "Metoda pozwala na nadanie podmiotowi wskazanemu w żądaniu uprawnień do obsługi faktur podmiotu kontekstu.  \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.  \nDla każdego uprawnienia może być ustawiona flaga **canDelegate**, mówiąca o możliwości jego dalszego przekazywania poprzez nadawanie w sposób pośredni.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-podmiotom-uprawnie%C5%84-do-obs%C5%82ugi-faktur)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie podmiotowi wskazanemu w żądaniu uprawnień do obsługi faktur podmiotu kontekstu.  \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.  \nDla każdego uprawnienia może być ustawiona flaga **canDelegate**, mówiąca o możliwości jego dalszego przekazywania poprzez nadawanie w sposób pośredni.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-podmiotom-uprawnie%C5%84-do-obs%C5%82ugi-faktur)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3611,7 +3206,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3660,9 +3255,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -3675,20 +3270,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie uprawnień podmiotowych",
-        "description": "Metoda pozwala na nadanie jednego z uprawnień podmiotowych do obsługi podmiotu kontekstu  podmiotowi wskazanemu w żądaniu.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-podmiotowych)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie jednego z uprawnień podmiotowych do obsługi podmiotu kontekstu  podmiotowi wskazanemu w żądaniu.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-podmiotowych)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3750,7 +3332,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3799,9 +3381,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -3814,20 +3396,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie uprawnień w sposób pośredni",
-        "description": "Metoda pozwala na nadanie w sposób pośredni osobie wskazanej w żądaniu uprawnień do obsługi faktur innego podmiotu – klienta.  \nMoże to być jedna z możliwości:  \n- nadanie uprawnień generalnych – do obsługi wszystkich klientów  \n- nadanie uprawnień selektywnych – do obsługi wskazanego klienta  \n            \nUprawnienie selektywne może być nadane wyłącznie wtedy, gdy klient nadał wcześniej podmiotowi bieżącego kontekstu dowolne uprawnienie z prawem do jego dalszego przekazywania (patrz [POST /v2/permissions/entities/grants](/docs/v2/index.html#tag/Nadawanie-uprawnien/paths/~1permissions~1entities~1grants/post)).  \n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-w-spos%C3%B3b-po%C5%9Bredni)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie w sposób pośredni osobie wskazanej w żądaniu uprawnień do obsługi faktur innego podmiotu – klienta.  \nMoże to być jedna z możliwości:  \n- nadanie uprawnień generalnych – do obsługi wszystkich klientów  \n- nadanie uprawnień selektywnych – do obsługi wskazanego klienta  \n            \nUprawnienie selektywne może być nadane wyłącznie wtedy, gdy klient nadał wcześniej podmiotowi bieżącego kontekstu dowolne uprawnienie z prawem do jego dalszego przekazywania (patrz [POST /v2/permissions/entities/grants](/docs/v2/index.html#tag/Nadawanie-uprawnien/paths/~1permissions~1entities~1grants/post)).  \n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-w-spos%C3%B3b-po%C5%9Bredni)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3900,7 +3469,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -3949,9 +3518,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -3964,20 +3533,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie uprawnień administratora podmiotu podrzędnego",
-        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień administratora w kontekście:  \n- wskazanego NIP podmiotu podrzędnego – wyłącznie jeżeli podmiot bieżącego kontekstu logowania ma rolę podmiotu nadrzędnego:\n  - **LocalGovernmentUnit** \n  - **VatGroupUnit**  \n- wskazanego lub utworzonego identyfikatora wewnętrznego  \n            \nWraz z utworzeniem administratora jednostki podrzędnej tworzony jest identyfikator wewnętrzny składający się z numeru NIP podmiotu kontekstu logowania oraz 5 cyfr unikalnie identyfikujących jednostkę wewnętrzną.\nOstatnia cyfra musi być poprawną sumą kontrolną, która jest obliczana według poniższego algorytmu.\n\nAlgorytm używa naprzemiennych wag (1×, 3×, 1×, 3×, ...), sumuje wyniki i zwraca resztę z dzielenia przez 10.\n\nPrzykład:\n- Wejście: \"6824515772-1234\" (bez cyfry kontrolnej)\n- Pozycja 0 (1. cyfra): 6 × 1 = 6\n- Pozycja 1 (2. cyfra): 8 × 3 = 24\n- Pozycja 2 (3. cyfra): 2 × 1 = 2\n- Pozycja 3 (4. cyfra): 4 × 3 = 12\n- Pozycja 4 (5. cyfra): 5 × 1 = 5\n- Pozycja 5 (6. cyfra): 1 × 3 = 3\n- Pozycja 6 (7. cyfra): 5 × 1 = 5\n- Pozycja 7 (8. cyfra): 7 × 3 = 21\n- Pozycja 8 (9. cyfra): 7 × 1 = 7\n- Pozycja 9 (10. cyfra): 2 × 3 = 6\n- Pozycja 10 (11. cyfra): 1 × 1 = 1\n- Pozycja 11 (12. cyfra): 2 × 3 = 6\n- Pozycja 12 (13. cyfra): 3 × 1 = 3\n- Pozycja 13 (14. cyfra): 4 × 3 = 12\n- Suma: 6 + 24 + 2 + 12 + 5 + 3 + 5 + 21 + 7 + 6 + 1 + 6 + 3 + 12 = 113\n- Cyfra kontrolna (15. cyfra): 113 % 10 = 3\n\nW żądaniu podaje się również nazwę tej jednostki.  \n            \nUprawnienia administratora jednostki podrzędnej obejmują:  \n- **CredentialsManage** – zarządzanie uprawnieniami  \n            \nMetoda automatycznie nadaje powyższe uprawnienie, bez konieczności podawania go w żądaniu.\n            \n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-administratora-podmiotu-podrz%C4%99dnego)\n\n**Wymagane uprawnienia**: `SubunitManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień administratora w kontekście:  \n- wskazanego NIP podmiotu podrzędnego – wyłącznie jeżeli podmiot bieżącego kontekstu logowania ma rolę podmiotu nadrzędnego:\n  - **LocalGovernmentUnit** \n  - **VatGroupUnit**  \n- wskazanego lub utworzonego identyfikatora wewnętrznego  \n            \nWraz z utworzeniem administratora jednostki podrzędnej tworzony jest identyfikator wewnętrzny składający się z numeru NIP podmiotu kontekstu logowania oraz 5 cyfr unikalnie identyfikujących jednostkę wewnętrzną.\nOstatnia cyfra musi być poprawną sumą kontrolną, która jest obliczana według poniższego algorytmu.\n\nAlgorytm używa naprzemiennych wag (1×, 3×, 1×, 3×, ...), sumuje wyniki i zwraca resztę z dzielenia przez 10.\n\nPrzykład:\n- Wejście: \"6824515772-1234\" (bez cyfry kontrolnej)\n- Pozycja 0 (1. cyfra): 6 × 1 = 6\n- Pozycja 1 (2. cyfra): 8 × 3 = 24\n- Pozycja 2 (3. cyfra): 2 × 1 = 2\n- Pozycja 3 (4. cyfra): 4 × 3 = 12\n- Pozycja 4 (5. cyfra): 5 × 1 = 5\n- Pozycja 5 (6. cyfra): 1 × 3 = 3\n- Pozycja 6 (7. cyfra): 5 × 1 = 5\n- Pozycja 7 (8. cyfra): 7 × 3 = 21\n- Pozycja 8 (9. cyfra): 7 × 1 = 7\n- Pozycja 9 (10. cyfra): 2 × 3 = 6\n- Pozycja 10 (11. cyfra): 1 × 1 = 1\n- Pozycja 11 (12. cyfra): 2 × 3 = 6\n- Pozycja 12 (13. cyfra): 3 × 1 = 3\n- Pozycja 13 (14. cyfra): 4 × 3 = 12\n- Suma: 6 + 24 + 2 + 12 + 5 + 3 + 5 + 21 + 7 + 6 + 1 + 6 + 3 + 12 = 113\n- Cyfra kontrolna (15. cyfra): 113 % 10 = 3\n\nW żądaniu podaje się również nazwę tej jednostki.  \n            \nUprawnienia administratora jednostki podrzędnej obejmują:  \n- **CredentialsManage** – zarządzanie uprawnieniami  \n            \nMetoda automatycznie nadaje powyższe uprawnienie, bez konieczności podawania go w żądaniu.\n            \n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-administratora-podmiotu-podrz%C4%99dnego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `SubunitManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4047,7 +3603,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4096,9 +3652,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "SubunitManage"
@@ -4111,20 +3667,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie uprawnień administratora podmiotu unijnego",
-        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień administratora w kontekście złożonym z identyfikatora NIP podmiotu kontekstu bieżącego oraz numeru VAT UE podmiotu unijnego wskazanego w żądaniu.  \nWraz z utworzeniem administratora podmiotu unijnego tworzony jest kontekst złożony składający się z numeru NIP podmiotu kontekstu logowania oraz wskazanego numeru identyfikacyjnego VAT UE podmiotu unijnego.  \nW żądaniu podaje się również nazwę i adres podmiotu unijnego.  \n            \nJedynym sposobem identyfikacji uprawnianego jest odcisk palca certyfikatu kwalifikowanego:  \n- certyfikat podpisu elektronicznego dla osób fizycznych  \n- certyfikat pieczęci elektronicznej dla podmiotów  \n            \nUprawnienia administratora podmiotu unijnego obejmują:  \n- **VatEuManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n- **Introspection** – przeglądanie historii sesji  \n            \nMetoda automatycznie nadaje wszystkie powyższe uprawnienia, bez konieczności ich wskazywania w żądaniu.\n            \n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-administratora-podmiotu-unijnego)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień administratora w kontekście złożonym z identyfikatora NIP podmiotu kontekstu bieżącego oraz numeru VAT UE podmiotu unijnego wskazanego w żądaniu.  \nWraz z utworzeniem administratora podmiotu unijnego tworzony jest kontekst złożony składający się z numeru NIP podmiotu kontekstu logowania oraz wskazanego numeru identyfikacyjnego VAT UE podmiotu unijnego.  \nW żądaniu podaje się również nazwę i adres podmiotu unijnego.  \n            \nJedynym sposobem identyfikacji uprawnianego jest odcisk palca certyfikatu kwalifikowanego:  \n- certyfikat podpisu elektronicznego dla osób fizycznych  \n- certyfikat pieczęci elektronicznej dla podmiotów  \n            \nUprawnienia administratora podmiotu unijnego obejmują:  \n- **VatEuManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n- **Introspection** – przeglądanie historii sesji  \n            \nMetoda automatycznie nadaje wszystkie powyższe uprawnienia, bez konieczności ich wskazywania w żądaniu.\n            \n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-administratora-podmiotu-unijnego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4204,7 +3747,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4253,9 +3796,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -4268,20 +3811,7 @@
           "Nadawanie uprawnień"
         ],
         "summary": "Nadanie uprawnień reprezentanta podmiotu unijnego",
-        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień do wystawiania i/lub przeglądania faktur w kontekście złożonym kontekstu bieżącego.  \n            \nJedynym sposobem identyfikacji uprawnianego jest odcisk palca certyfikatu kwalifikowanego:  \n- certyfikat podpisu elektronicznego dla osób fizycznych  \n- certyfikat pieczęci elektronicznej dla podmiotów  \n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-reprezentanta-podmiotu-unijnego)\n\n**Wymagane uprawnienia**: `VatUeManage`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Metoda pozwala na nadanie wskazanemu w żądaniu podmiotowi lub osobie fizycznej uprawnień do wystawiania i/lub przeglądania faktur w kontekście złożonym kontekstu bieżącego.  \n            \nJedynym sposobem identyfikacji uprawnianego jest odcisk palca certyfikatu kwalifikowanego:  \n- certyfikat podpisu elektronicznego dla osób fizycznych  \n- certyfikat pieczęci elektronicznej dla podmiotów  \n            \nW żądaniu określane są nadawane uprawnienia ze zbioru:  \n- **InvoiceWrite** – wystawianie faktur  \n- **InvoiceRead** – przeglądanie faktur  \n            \nMetoda pozwala na wybór dowolnej kombinacji powyższych uprawnień.\n\n> Więcej informacji:\n> - [Nadawanie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#nadanie-uprawnie%C5%84-reprezentanta-podmiotu-unijnego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `VatUeManage`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4354,7 +3884,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4403,9 +3933,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "VatUeManage"
@@ -4418,7 +3948,7 @@
           "Odbieranie uprawnień"
         ],
         "summary": "Odebranie uprawnień",
-        "description": "Metoda pozwala na odebranie uprawnienia o wskazanym identyfikatorze.  \nWymagane jest wcześniejsze odczytanie uprawnień w celu uzyskania  \nidentyfikatora uprawnienia, które ma zostać odebrane.\n\n> Więcej informacji:\n> - [Odbieranie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#odebranie-uprawnie%C5%84)\n\n**Wymagane uprawnienia**: `CredentialsManage`, `VatUeManage`, `SubunitManage`.",
+        "description": "Metoda pozwala na odebranie uprawnienia o wskazanym identyfikatorze.  \nWymagane jest wcześniejsze odczytanie uprawnień w celu uzyskania  \nidentyfikatora uprawnienia, które ma zostać odebrane.\n\n> Więcej informacji:\n> - [Odbieranie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#odebranie-uprawnie%C5%84)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`, `VatUeManage`, `SubunitManage`.",
         "parameters": [
           {
             "name": "permissionId",
@@ -4427,17 +3957,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/PermissionId"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -4472,7 +3991,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4521,9 +4040,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage",
@@ -4538,7 +4057,7 @@
           "Odbieranie uprawnień"
         ],
         "summary": "Odebranie uprawnień podmiotowych",
-        "description": "Metoda pozwala na odebranie uprawnienia podmiotowego o wskazanym identyfikatorze.  \nWymagane jest wcześniejsze odczytanie uprawnień w celu uzyskania  \nidentyfikatora uprawnienia, które ma zostać odebrane.\n            \n> Więcej informacji:\n> - [Odbieranie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#odebranie-uprawnie%C5%84-podmiotowych)\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
+        "description": "Metoda pozwala na odebranie uprawnienia podmiotowego o wskazanym identyfikatorze.  \nWymagane jest wcześniejsze odczytanie uprawnień w celu uzyskania  \nidentyfikatora uprawnienia, które ma zostać odebrane.\n            \n> Więcej informacji:\n> - [Odbieranie uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#odebranie-uprawnie%C5%84-podmiotowych)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`.",
         "parameters": [
           {
             "name": "permissionId",
@@ -4547,17 +4066,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/PermissionId"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -4592,7 +4100,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4641,9 +4149,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage"
@@ -4656,7 +4164,7 @@
           "Operacje"
         ],
         "summary": "Pobranie statusu operacji",
-        "description": "Zwraca status operacji asynchronicznej związanej z nadaniem lub odebraniem uprawnień.       \n\nStatus operacji jest dostępny przez 30 dni.",
+        "description": "Zwraca status operacji asynchronicznej związanej z nadaniem lub odebraniem uprawnień.       \n\nStatus operacji jest dostępny przez 30 dni.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -4665,17 +4173,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -4731,7 +4228,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4780,9 +4277,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -4792,20 +4289,7 @@
           "Operacje"
         ],
         "summary": "Sprawdzenie statusu zgody na wystawianie faktur z załącznikiem",
-        "description": "Sprawdzenie czy obecny kontekst posiada zgodę na wystawianie faktur z załącznikiem.\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Sprawdzenie czy obecny kontekst posiada zgodę na wystawianie faktur z załącznikiem.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
         "responses": {
           "200": {
             "description": "OK",
@@ -4834,7 +4318,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -4883,9 +4367,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "CredentialsManage",
@@ -4899,7 +4383,7 @@
           "Pobieranie faktur"
         ],
         "summary": "Pobranie faktury po numerze KSeF",
-        "description": "Zwraca fakturę o podanym numerze KSeF.\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
+        "description": "Zwraca fakturę o podanym numerze KSeF.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
         "parameters": [
           {
             "name": "ksefNumber",
@@ -4908,17 +4392,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/KsefNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -4958,7 +4431,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 80 | 160 | 640 | invoiceDownload\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 8 | 16 | 64 | invoiceDownload\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5007,9 +4480,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 80,
-          "perMinute": 160,
-          "perHour": 640
+          "perSecond": 8,
+          "perMinute": 16,
+          "perHour": 64
         },
         "x-required-permissions": [
           "InvoiceRead"
@@ -5022,7 +4495,7 @@
           "Pobieranie faktur"
         ],
         "summary": "Pobranie listy metadanych faktur",
-        "description": "Zwraca metadane faktur spełniających filtry.\n\nLimit techniczny: ≤ 10 000 rekordów na zestaw filtrów, po jego osiągnięciu <b>isTruncated = true</b> i należy ponownie ustawić <b>dateRange</b>, używając ostatniej daty z wyników (tj. ustawić from/to - w zależności od kierunku sortowania, od daty ostatniego zwróconego rekordu) oraz wyzerować <b>pageOffset</b>.\n\n`Do scenariusza przyrostowego należy używać daty PermanentStorage oraz kolejność sortowania Asc`.\n            \n<b>Scenariusz pobierania przyrostowego (skrót):</b>\n* Gdy <b>hasMore = false</b>, należy zakończyć,\n* Gdy <b>hasMore = true</b> i <b>isTruncated = false</b>, należy zwiększyć <b>pageOffset</b>,\n* Gdy <b>hasMore = true</b> i <b>isTruncated = true</b>, należy zawęzić <b>dateRange</b> (ustawić from od daty ostatniego rekordu), wyzerować <b>pageOffset</b> i kontynuować\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc | Desc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
+        "description": "Zwraca metadane faktur spełniających filtry.\n\nLimit techniczny: ≤ 10 000 rekordów na zestaw filtrów, po jego osiągnięciu <b>isTruncated = true</b> i należy ponownie ustawić <b>dateRange</b>, używając ostatniej daty z wyników (tj. ustawić from/to - w zależności od kierunku sortowania, od daty ostatniego zwróconego rekordu) oraz wyzerować <b>pageOffset</b>.\n\n`Do scenariusza przyrostowego należy używać daty PermanentStorage oraz kolejność sortowania Asc`.\n            \n<b>Scenariusz pobierania przyrostowego (skrót):</b>\n* Gdy <b>hasMore = false</b>, należy zakończyć,\n* Gdy <b>hasMore = true</b> i <b>isTruncated = false</b>, należy zwiększyć <b>pageOffset</b>,\n* Gdy <b>hasMore = true</b> i <b>isTruncated = true</b>, należy zawęzić <b>dateRange</b> (ustawić from od daty ostatniego rekordu), wyzerować <b>pageOffset</b> i kontynuować\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc | Desc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
         "parameters": [
           {
             "name": "sortOrder",
@@ -5059,17 +4532,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -5226,7 +4688,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 80 | 160 | 200 | invoiceMetadata\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 8 | 16 | 20 | invoiceMetadata\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5275,9 +4737,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 80,
-          "perMinute": 160,
-          "perHour": 200
+          "perSecond": 8,
+          "perMinute": 16,
+          "perHour": 20
         },
         "x-sort": [
           {
@@ -5303,20 +4765,7 @@
           "Pobieranie faktur"
         ],
         "summary": "Eksport paczki faktur",
-        "description": "Rozpoczyna asynchroniczny proces wyszukiwania faktur w systemie KSeF na podstawie przekazanych filtrów oraz przygotowania ich w formie zaszyfrowanej paczki.\nWymagane jest przekazanie informacji o szyfrowaniu w polu <b>Encryption</b>, które służą do zabezpieczenia przygotowanej paczki z fakturami.\nMaksymalnie można uruchomić 10 równoczesnych eksportów w zalogowanym kontekście.\n            \nSystem pobiera faktury rosnąco według daty określonej w filtrze (Invoicing, Issue, PermanentStorage) i dodaje faktury(nazwa pliku: <b>{ksefNumber}.xml</b>) do paczki aż do osiągnięcia jednego z poniższych limitów:\n* Limit liczby faktur: 10 000 sztuk\n* Limit rozmiaru danych(skompresowanych): 1GB\n\nPaczka eksportu zawiera dodatkowy plik z metadanymi faktur w formacie JSON (`_metadata.json`). Zawartość pliku to\nobiekt z tablicą <b>invoices</b>, gdzie każdy element jest obiektem typu <b>InvoiceMetadata</b>\n(taki jak zwracany przez endpoint `POST /invoices/query/metadata`).\n\n<b>Plik z metadanymi(_metadata.json) nie jest wliczany do limitów algorytmu budowania paczki</b>. \n\n`Do realizacji pobierania przyrostowego należy stosować filtrowanie po dacie PermanentStorage`.\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Rozpoczyna asynchroniczny proces wyszukiwania faktur w systemie KSeF na podstawie przekazanych filtrów oraz przygotowania ich w formie zaszyfrowanej paczki.\nWymagane jest przekazanie informacji o szyfrowaniu w polu <b>Encryption</b>, które służą do zabezpieczenia przygotowanej paczki z fakturami.\nMaksymalnie można uruchomić 10 równoczesnych eksportów w zalogowanym kontekście.\n            \nSystem pobiera faktury rosnąco według daty określonej w filtrze (Invoicing, Issue, PermanentStorage) i dodaje faktury(nazwa pliku: <b>{ksefNumber}.xml</b>) do paczki aż do osiągnięcia jednego z poniższych limitów:\n* Limit liczby faktur: 10 000 sztuk\n* Limit rozmiaru danych(skompresowanych): 1GB\n\nPaczka eksportu zawiera dodatkowy plik z metadanymi faktur w formacie JSON (`_metadata.json`). Zawartość pliku to\nobiekt z tablicą <b>invoices</b>, gdzie każdy element jest obiektem typu <b>InvoiceMetadata</b>\n(taki jak zwracany przez endpoint `POST /invoices/query/metadata`).\n\n<b>Plik z metadanymi(_metadata.json) nie jest wliczany do limitów algorytmu budowania paczki</b>. \n\n`Do realizacji pobierania przyrostowego należy stosować filtrowanie po dacie PermanentStorage`.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
         "requestBody": {
           "description": "Dane wejściowe określające kryteria i format eksportu paczki faktur.",
           "content": {
@@ -5335,7 +4784,8 @@
               "example": {
                 "encryption": {
                   "encryptedSymmetricKey": "bdUVjqLj+y2q6aBUuLxxXYAMqeDuIBRTyr+hB96DaWKaGzuVHw9p+Nk9vhzgF/Q5cavK2k6eCh6SdsrWI0s9mFFj4A4UJtsyD8Dn3esLfUZ5A1juuG3q3SBi/XOC/+9W+0T/KdwdE393mbiUNyx1K/0bw31vKJL0COeJIDP7usAMDl42/H1TNvkjk+8iZ80V0qW7D+RZdz+tdiY1xV0f2mfgwJ46V0CpZ+sB9UAssRj+eVffavJ0TOg2b5JaBxE8MCAvrF6rO5K4KBjUmoy7PP7g1qIbm8xI2GO0KnfPOO5OWj8rsotRwBgu7x19Ine3qYUvuvCZlXRGGZ5NHIzWPM4O74+gNalaMgFCsmv8mMhETSU4SfAGmJr9edxPjQSbgD5i2X4eDRDMwvyaAa7CP1b2oICju+0L7Fywd2ZtUcr6El++eTVoi8HYsTArntET++gULT7XXjmb8e3O0nxrYiYsE9GMJ7HBGv3NOoJ1NTm3a7U6+c0ZJiBVLvn6xXw10LQX243xH+ehsKo6djQJKYtqcNPaXtCwM1c9RrsOx/wRXyWCtTffqLiaR0LbYvfMJAcEWceG+RaeAx4p37OiQqdJypd6LAv9/0ECWK8Bip8yyoA+0EYiAJb9YuDz2YlQX9Mx9E9FzFIAsgEQ2w723HZYWgPywLb+dlsum4lTZKQ=",
-                  "initializationVector": "c29tZUluaXRWZWN0b3I="
+                  "initializationVector": "c29tZUluaXRWZWN0b3I=",
+                  "publicKeyId": "tmtCidSRzR4fvNpLU5hMOM6FzamxJf0BBR8IkXIAwsY="
                 },
                 "onlyMetadata": false,
                 "filters": {
@@ -5366,7 +4816,7 @@
             }
           },
           "400": {
-            "description": "| ExceptionCode       | ExceptionDescription                                | Details                                                       | \n|---------------------|-----------------------------------------------------|---------------------------------------------------------------|\n| 21181               | Nieprawidłowe żądanie eksportu faktur.              | Nie można wyeksportować paczki faktur dla wybranego podmiotu ({subjecttype}) i zalogowanego identyfikatora kontekstu ({type}). |\n| 21182               | Osiągnięto limit trwających eksportów.              | Dla uwierzytelnionego podmiotu w bieżącym kontekście osiągnięto maksymalny limit {count} równoczesnych eksportów faktur. Spróbuj ponownie później. |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
+            "description": "| ExceptionCode       | ExceptionDescription                                | Details                                                       | \n|---------------------|-----------------------------------------------------|---------------------------------------------------------------|\n| 21181               | Nieprawidłowe żądanie eksportu faktur.              | Nie można wyeksportować paczki faktur dla wybranego podmiotu ({subjecttype}) i zalogowanego identyfikatora kontekstu ({type}). |\n| 21182               | Osiągnięto limit trwających eksportów.              | Dla uwierzytelnionego podmiotu w bieżącym kontekście osiągnięto maksymalny limit {count} równoczesnych eksportów faktur. Spróbuj ponownie później. |\n| 21470               | Przesłany identyfikator klucza jest nieznany lub wskazuje na wycofany klucz. | Klucz o identyfikatorze {keyId} nie jest wspierany. |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
             "content": {
               "application/json": {
                 "schema": {
@@ -5382,7 +4832,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 80 | 160 | 200 | invoiceExport\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 8 | 16 | 20 | invoiceExport\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5431,9 +4881,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 80,
-          "perMinute": 160,
-          "perHour": 200
+          "perSecond": 8,
+          "perMinute": 16,
+          "perHour": 20
         },
         "x-sort": [
           {
@@ -5456,7 +4906,7 @@
           "Pobieranie faktur"
         ],
         "summary": "Pobranie statusu eksportu paczki faktur",
-        "description": "Paczka faktur jest dzielona na części o maksymalnym rozmiarze 50 MB. Każda część jest zaszyfrowana algorytmem AES-256-CBC z dopełnieniem PKCS#7, przy użyciu klucza symetrycznego przekazanego podczas inicjowania eksportu. \n\nW przypadku ucięcia wyniku eksportu z powodu przekroczenia limitów, zwracana jest flaga <b>IsTruncated = true</b> oraz odpowiednia data, którą należy wykorzystać do wykonania kolejnego eksportu, aż do momentu, gdy flaga <b>IsTruncated = false</b>.\n\nStatus eksportu paczki faktur jest dostępny przez 7 dni.\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
+        "description": "Paczka faktur jest dzielona na części o maksymalnym rozmiarze 50 MB. Każda część jest zaszyfrowana algorytmem AES-256-CBC z dopełnieniem PKCS#7, przy użyciu klucza symetrycznego przekazanego podczas inicjowania eksportu. \n\nW przypadku ucięcia wyniku eksportu z powodu przekroczenia limitów, zwracana jest flaga <b>IsTruncated = true</b> oraz odpowiednia data, którą należy wykorzystać do wykonania kolejnego eksportu, aż do momentu, gdy flaga <b>IsTruncated = false</b>.\n\nStatus eksportu paczki faktur jest dostępny przez 7 dni.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- permanentStorageDate | invoicingDate | issueDate (Asc) - pole wybierane na podstawie filtrów\n\n\n\n**Wymagane uprawnienia**: `InvoiceRead`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -5465,17 +4915,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -5552,7 +4991,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 600 | 6000 | invoiceExportStatus\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 60 | 600 | invoiceExportStatus\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5601,9 +5040,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 600,
-          "perHour": 6000
+          "perSecond": 10,
+          "perMinute": 60,
+          "perHour": 600
         },
         "x-sort": [
           {
@@ -5626,7 +5065,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie listy sesji",
-        "description": "Zwraca listę sesji spełniających podane kryteria wyszukiwania.\n\n\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n\n\n**Wymagane uprawnienia**:\n- `Introspection`/`EnforcementOperations` – pozwala pobrać wszystkie sesje w bieżącym kontekście uwierzytelnienia `(ContextIdentifier)`.\n- `InvoiceWrite` – pozwala pobrać wyłącznie sesje utworzone przez podmiot uwierzytelniający, czyli podmiot inicjujący uwierzytelnienie.",
+        "description": "Zwraca listę sesji spełniających podane kryteria wyszukiwania.\n\n\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n\n\n**Wymagane uprawnienia**:\n- `Introspection`/`EnforcementOperations` – pozwala pobrać wszystkie sesje w bieżącym kontekście uwierzytelnienia `(ContextIdentifier)`.\n- `InvoiceWrite` – pozwala pobrać wyłącznie sesje utworzone przez podmiot uwierzytelniający, czyli podmiot inicjujący uwierzytelnienie.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "pageSize",
@@ -5733,17 +5172,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -5805,7 +5233,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 50 | 100 | 600 | sessionList\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 5 | 10 | 60 | sessionList\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5854,9 +5282,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 50,
-          "perMinute": 100,
-          "perHour": 600
+          "perSecond": 5,
+          "perMinute": 10,
+          "perHour": 60
         },
         "x-sort": [
           {
@@ -5877,7 +5305,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie statusu sesji",
-        "description": "Sprawdza bieżący status sesji o podanym numerze referencyjnym.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Sprawdza bieżący status sesji o podanym numerze referencyjnym.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -5886,17 +5314,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -5948,7 +5365,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 1200 | 12000 | sessionMisc\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 120 | 1200 | sessionMisc\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -5997,9 +5414,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 1200,
-          "perHour": 12000
+          "perSecond": 10,
+          "perMinute": 120,
+          "perHour": 1200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6015,7 +5432,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie faktur sesji",
-        "description": "Zwraca listę faktur przesłanych w sesji wraz z ich statusami, oraz informacje na temat ilości poprawnie i niepoprawnie przetworzonych faktur.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca listę faktur przesłanych w sesji wraz z ich statusami, oraz informacje na temat ilości poprawnie i niepoprawnie przetworzonych faktur.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "x-continuation-token",
@@ -6044,17 +5461,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6124,7 +5530,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 200 | 2000 | sessionInvoiceList\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 20 | 200 | sessionInvoiceList\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6173,9 +5579,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 200,
-          "perHour": 2000
+          "perSecond": 10,
+          "perMinute": 20,
+          "perHour": 200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6191,7 +5597,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie statusu faktury z sesji",
-        "description": "Zwraca fakturę przesłaną w sesji wraz ze statusem.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca fakturę przesłaną w sesji wraz ze statusem.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -6209,17 +5615,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6267,7 +5662,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 300 | 1200 | 12000 | invoiceStatus\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 30 | 120 | 1200 | invoiceStatus\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6316,9 +5711,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 300,
-          "perMinute": 1200,
-          "perHour": 12000
+          "perSecond": 30,
+          "perMinute": 120,
+          "perHour": 1200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6334,7 +5729,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie niepoprawnie przetworzonych faktur sesji",
-        "description": "Zwraca listę niepoprawnie przetworzonych faktur przesłanych w sesji wraz z ich statusami.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca listę niepoprawnie przetworzonych faktur przesłanych w sesji wraz z ich statusami.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "x-continuation-token",
@@ -6363,17 +5758,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6428,7 +5812,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 200 | 2000 | sessionInvoiceList\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 20 | 200 | sessionInvoiceList\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6477,9 +5861,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 200,
-          "perHour": 2000
+          "perSecond": 10,
+          "perMinute": 20,
+          "perHour": 200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6495,7 +5879,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie UPO faktury z sesji na podstawie numeru KSeF",
-        "description": "Zwraca UPO faktury przesłanego w sesji na podstawie jego numeru KSeF.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca UPO faktury przesłanego w sesji na podstawie jego numeru KSeF.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -6513,17 +5897,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/KsefNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6563,7 +5936,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 1200 | 12000 | sessionMisc\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 120 | 1200 | sessionMisc\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6612,9 +5985,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 1200,
-          "perHour": 12000
+          "perSecond": 10,
+          "perMinute": 120,
+          "perHour": 1200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6630,7 +6003,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie UPO faktury z sesji na podstawie numeru referencyjnego faktury",
-        "description": "Zwraca UPO faktury przesłanego w sesji na podstawie jego numeru KSeF.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca UPO faktury przesłanego w sesji na podstawie jego numeru KSeF.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -6648,17 +6021,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6698,7 +6060,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 1200 | 12000 | sessionMisc\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 120 | 1200 | sessionMisc\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6747,9 +6109,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 1200,
-          "perHour": 12000
+          "perSecond": 10,
+          "perMinute": 120,
+          "perHour": 1200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6765,7 +6127,7 @@
           "Status wysyłki i UPO"
         ],
         "summary": "Pobranie UPO dla sesji",
-        "description": "Zwraca XML zawierający zbiorcze UPO dla sesji.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zwraca XML zawierający zbiorcze UPO dla sesji.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `Introspection`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -6783,17 +6145,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -6833,7 +6184,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 1200 | 12000 | sessionMisc\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 120 | 1200 | sessionMisc\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -6882,9 +6233,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 1200,
-          "perHour": 12000
+          "perSecond": 10,
+          "perMinute": 120,
+          "perHour": 1200
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -6900,20 +6251,7 @@
           "Tokeny KSeF"
         ],
         "summary": "Wygenerowanie nowego tokena",
-        "description": "Zwraca token, który może być użyty do uwierzytelniania się w KSeF.\n\nToken może być generowany tylko w kontekście NIP lub identyfikatora wewnętrznego. Jest zwracany tylko raz. Zaczyna być aktywny w momencie gdy jego status zmieni się na `Active`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Zwraca token, który może być użyty do uwierzytelniania się w KSeF.\n\nToken może być generowany tylko w kontekście NIP lub identyfikatora wewnętrznego. Jest zwracany tylko raz. Zaczyna być aktywny w momencie gdy jego status zmieni się na `Active`.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6970,7 +6308,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -7019,9 +6357,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       },
       "get": {
@@ -7029,7 +6367,7 @@
           "Tokeny KSeF"
         ],
         "summary": "Pobranie listy wygenerowanych tokenów",
-        "description": "Zwraca listę metadanych tokenów. Zakres wyników zależy od sposobu uwierzytelnienia oraz uprawnień podmiotu wywołującego.\n\nJeżeli podmiot posiada uprawnienie **CredentialsManage** lub **CredentialsRead**, \nusługa zwraca wszystkie tokeny wygenerowane w danym kontekście niezależnie od metody uwierzytelnienia. \n\nJeżeli podmiot nie posiada żadnego z powyższych uprawnień, zakres wyników jest ograniczony: \n- Dla podmiotu uwierzytelnionego tokenem zwracany jest wyłącznie token użyty do uwierzytelnienia.\n- Dla pozostałych metod uwierzytelnienia zwracane są tokeny,  \nktórych autorem jest wywołujący podmiot – z uwzględnieniem powiązania NIP–PESEL.\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n\n",
+        "description": "Zwraca listę metadanych tokenów. Zakres wyników zależy od sposobu uwierzytelnienia oraz uprawnień podmiotu wywołującego.\n\nJeżeli podmiot posiada uprawnienie **CredentialsManage** lub **CredentialsRead**, \nusługa zwraca wszystkie tokeny wygenerowane w danym kontekście niezależnie od metody uwierzytelnienia. \n\nJeżeli podmiot nie posiada żadnego z powyższych uprawnień, zakres wyników jest ograniczony: \n- Dla podmiotu uwierzytelnionego tokenem zwracany jest wyłącznie token użyty do uwierzytelnienia.\n- Dla pozostałych metod uwierzytelnienia zwracane są tokeny,  \nktórych autorem jest wywołujący podmiot – z uwzględnieniem powiązania NIP–PESEL.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n\n",
         "parameters": [
           {
             "name": "status",
@@ -7091,17 +6429,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -7156,7 +6483,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -7205,9 +6532,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -7223,6 +6550,7 @@
           "Tokeny KSeF"
         ],
         "summary": "Pobranie statusu tokena",
+        "description": "\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -7231,17 +6559,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -7293,7 +6610,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -7342,9 +6659,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       },
       "delete": {
@@ -7352,7 +6669,7 @@
           "Tokeny KSeF"
         ],
         "summary": "Unieważnienie tokena",
-        "description": "Unieważnia token o podanym numerze referencyjnym. Zakres tokenów dostępnych do unieważnienia zależy od sposobu uwierzytelnienia oraz uprawnień podmiotu wywołującego.\n\nJeżeli podmiot posiada uprawnienie **CredentialsManage**, \nmoże unieważnić dowolny aktywny token w danym kontekście niezależnie od metody uwierzytelnienia.\n\nJeżeli podmiot nie posiada powyższego uprawnienia, zakres unieważnienia jest ograniczony: \n- Dla podmiotu uwierzytelnionego tokenem możliwe jest unieważnienie wyłącznie tokena użytego do uwierzytelnienia. \n- Dla pozostałych metod uwierzytelnienia podmiot może unieważnić tokeny,  \nktórych jest autorem – z uwzględnieniem powiązania NIP–PESEL.",
+        "description": "Unieważnia token o podanym numerze referencyjnym. Zakres tokenów dostępnych do unieważnienia zależy od sposobu uwierzytelnienia oraz uprawnień podmiotu wywołującego.\n\nJeżeli podmiot posiada uprawnienie **CredentialsManage**, \nmoże unieważnić dowolny aktywny token w danym kontekście niezależnie od metody uwierzytelnienia.\n\nJeżeli podmiot nie posiada powyższego uprawnienia, zakres unieważnienia jest ograniczony: \n- Dla podmiotu uwierzytelnionego tokenem możliwe jest unieważnienie wyłącznie tokena użytego do uwierzytelnienia. \n- Dla pozostałych metod uwierzytelnienia podmiot może unieważnić tokeny,  \nktórych jest autorem – z uwzględnieniem powiązania NIP–PESEL.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -7361,17 +6678,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -7396,7 +6702,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -7445,9 +6751,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         }
       }
     },
@@ -7457,7 +6763,7 @@
           "Usługi Peppol"
         ],
         "summary": "Pobranie listy dostawców usług Peppol",
-        "description": "Zwraca listę dostawców usług Peppol zarejestrowanych w systemie.\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n- id (Asc)\n\n",
+        "description": "Zwraca listę dostawców usług Peppol zarejestrowanych w systemie.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- dateCreated (Desc)\n- id (Asc)\n\n",
         "parameters": [
           {
             "name": "pageOffset",
@@ -7480,17 +6786,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -7576,20 +6871,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Inicjalizacja uwierzytelnienia",
-        "description": "Generuje unikalny challenge wymagany w kolejnym kroku operacji uwierzytelnienia.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Generuje unikalny challenge wymagany w kolejnym kroku operacji uwierzytelnienia.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -7658,7 +6940,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Uwierzytelnienie z wykorzystaniem podpisu XAdES",
-        "description": "Rozpoczyna operację uwierzytelniania za pomocą dokumentu XML podpisanego podpisem elektronicznym XAdES.\n\n> Więcej informacji:\n> - [Przygotowanie dokumentu XML](https://github.com/CIRFMF/ksef-docs/blob/main/uwierzytelnianie.md#1-przygotowanie-dokumentu-xml-authtokenrequest)\n> - [Podpis dokumentu XML](https://github.com/CIRFMF/ksef-docs/blob/main/uwierzytelnianie.md#2-podpisanie-dokumentu-xades)\n> - [Schemat XSD](/docs/v2/schemas/authv2.xsd)",
+        "description": "Rozpoczyna operację uwierzytelniania za pomocą dokumentu XML podpisanego podpisem elektronicznym XAdES.\n\n> Więcej informacji:\n> - [Przygotowanie dokumentu XML](https://github.com/CIRFMF/ksef-docs/blob/main/uwierzytelnianie.md#1-przygotowanie-dokumentu-xml-authtokenrequest)\n> - [Podpis dokumentu XML](https://github.com/CIRFMF/ksef-docs/blob/main/uwierzytelnianie.md#2-podpisanie-dokumentu-xades)\n> - Obsługiwane schematy:\n>   - [auth v2.0](https://github.com/CIRFMF/ksef-docs/blob/main/auth/schemy/schemat_auth_v2-0.xsd)\n>   - [auth v2.1](https://github.com/CIRFMF/ksef-docs/blob/main/auth/schemy/schemat_auth_v2-1.xsd)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "verifyCertificateChain",
@@ -7666,17 +6948,6 @@
             "description": "Wymuszenie weryfikacji zaufania łańcucha certyfikatu wraz ze sprawdzeniem statusu certyfikatu (OCSP/CRL) na środowiskach które umożliwiają wykorzystanie samodzielnie wygenerowanych certyfikatów.",
             "schema": {
               "type": "boolean"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -7760,20 +7031,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Uwierzytelnienie z wykorzystaniem tokena KSeF",
-        "description": "Rozpoczyna operację uwierzytelniania z wykorzystaniem wcześniej wygenerowanego tokena KSeF.\n\nToken KSeF wraz z timestampem ze wcześniej wygenerowanego challenge'a (w formacie ```token|timestamp```) powinien zostać zaszyfrowany dedykowanym do tego celu kluczem publicznym.\n- Timestamp powinien zostać przekazany jako **liczba milisekund od 1 stycznia 1970 roku (Unix timestamp)**.\n- Algorytm szyfrowania: **RSA-OAEP (z użyciem SHA-256 jako funkcji skrótu)**.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Rozpoczyna operację uwierzytelniania z wykorzystaniem wcześniej wygenerowanego tokena KSeF.\n\nToken KSeF wraz z timestampem ze wcześniej wygenerowanego challenge'a (w formacie ```token|timestamp```) powinien zostać zaszyfrowany dedykowanym do tego celu kluczem publicznym.\n- Timestamp powinien zostać przekazany jako **liczba milisekund od 1 stycznia 1970 roku (Unix timestamp)**.\n- Algorytm szyfrowania: **RSA-OAEP (z użyciem SHA-256 jako funkcji skrótu)**.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7795,7 +7053,8 @@
                   "type": "Nip",
                   "value": "5265877635"
                 },
-                "encryptedToken": "..."
+                "encryptedToken": "...",
+                "publicKeyId": "QIoAK/Yc3s27Z4t3SZY4Mhp8JNLH7Vl4N3lNlJAEig8="
               }
             }
           }
@@ -7819,7 +7078,7 @@
             }
           },
           "400": {
-            "description": "| ExceptionCode       | ExceptionDescription                           | Details                                                                     | \n|---------------------|------------------------------------------------|-----------------------------------------------------------------------------|\n| 21111               | Nieprawidłowe wyzwanie autoryzacyjne.          |  |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
+            "description": "| ExceptionCode       | ExceptionDescription                                                         | Details                                             | \n|---------------------|------------------------------------------------------------------------------|-----------------------------------------------------|\n| 21111               | Nieprawidłowe wyzwanie autoryzacyjne.                                        |                                                     |\n| 21470               | Przesłany identyfikator klucza jest nieznany lub wskazuje na wycofany klucz. | Klucz o identyfikatorze {keyId} nie jest wspierany. |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
             "content": {
               "application/json": {
                 "schema": {
@@ -7869,7 +7128,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Pobranie statusu uwierzytelniania",
-        "description": "Sprawdza bieżący status operacji uwierzytelniania dla podanego tokena.\n\nSposób uwierzytelnienia: `AuthenticationToken` otrzymany przy rozpoczęciu operacji uwierzytelniania.\nOperacja jest dostępna przez 7 dni.",
+        "description": "Sprawdza bieżący status operacji uwierzytelniania dla podanego tokena.\n\nSposób uwierzytelnienia: `AuthenticationToken` otrzymany przy rozpoczęciu operacji uwierzytelniania.\nOperacja jest dostępna przez 7 dni.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -7878,17 +7137,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -8094,20 +7342,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Pobranie tokenów dostępowych",
-        "description": "Pobiera parę tokenów (access token i refresh token) wygenerowanych w ramach pozytywnie zakończonego procesu uwierzytelniania.\n**Tokeny można pobrać tylko raz.**\n\nSposób uwierzytelnienia: `AuthenticationToken` otrzymany przy rozpoczęciu operacji uwierzytelniania.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Pobiera parę tokenów (access token i refresh token) wygenerowanych w ramach pozytywnie zakończonego procesu uwierzytelniania.\n**Tokeny można pobrać tylko raz.**\n\nSposób uwierzytelnienia: `AuthenticationToken` otrzymany przy rozpoczęciu operacji uwierzytelniania.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -8205,20 +7440,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Odświeżenie tokena dostępowego",
-        "description": "Generuje nowy token dostępu na podstawie ważnego refresh tokena.\n\nSposób uwierzytelnienia: `RefreshToken`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Generuje nowy token dostępu na podstawie ważnego refresh tokena.\n\nSposób uwierzytelnienia: `RefreshToken`.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "responses": {
           "200": {
             "description": "OK",
@@ -8312,20 +7534,7 @@
           "Wysyłka interaktywna"
         ],
         "summary": "Otwarcie sesji interaktywnej",
-        "description": "Otwiera sesję do wysyłki pojedynczych faktur. Należy przekazać schemat wysyłanych faktur oraz informacje o kluczu używanym do szyfrowania.\n\n> Więcej informacji:\n> - [Otwarcie sesji interaktywnej](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-interaktywna.md#1-otwarcie-sesji)\n> - [Klucz publiczny Ministerstwa Finansów](/docs/v2/index.html#tag/Certyfikaty-klucza-publicznego)\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Otwiera sesję do wysyłki pojedynczych faktur. Należy przekazać schemat wysyłanych faktur oraz informacje o kluczu używanym do szyfrowania.\n\n> Więcej informacji:\n> - [Otwarcie sesji interaktywnej](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-interaktywna.md#1-otwarcie-sesji)\n> - [Klucz publiczny Ministerstwa Finansów](/docs/v2/index.html#tag/Certyfikaty-klucza-publicznego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8348,7 +7557,8 @@
                 },
                 "encryption": {
                   "encryptedSymmetricKey": "bdUVjqLj+y2q6aBUuLxxXYAMqeDuIBRTyr+hB96DaWKaGzuVHw9p+Nk9vhzgF/Q5cavK2k6eCh6SdsrWI0s9mFFj4A4UJtsyD8Dn3esLfUZ5A1juuG3q3SBi/XOC/+9W+0T/KdwdE393mbiUNyx1K/0bw31vKJL0COeJIDP7usAMDl42/H1TNvkjk+8iZ80V0qW7D+RZdz+tdiY1xV0f2mfgwJ46V0CpZ+sB9UAssRj+eVffavJ0TOg2b5JaBxE8MCAvrF6rO5K4KBjUmoy7PP7g1qIbm8xI2GO0KnfPOO5OWj8rsotRwBgu7x19Ine3qYUvuvCZlXRGGZ5NHIzWPM4O74+gNalaMgFCsmv8mMhETSU4SfAGmJr9edxPjQSbgD5i2X4eDRDMwvyaAa7CP1b2oICju+0L7Fywd2ZtUcr6El++eTVoi8HYsTArntET++gULT7XXjmb8e3O0nxrYiYsE9GMJ7HBGv3NOoJ1NTm3a7U6+c0ZJiBVLvn6xXw10LQX243xH+ehsKo6djQJKYtqcNPaXtCwM1c9RrsOx/wRXyWCtTffqLiaR0LbYvfMJAcEWceG+RaeAx4p37OiQqdJypd6LAv9/0ECWK8Bip8yyoA+0EYiAJb9YuDz2YlQX9Mx9E9FzFIAsgEQ2w723HZYWgPywLb+dlsum4lTZKQ=",
-                  "initializationVector": "OmtDQdl6vkOI1GLKZSjgEg=="
+                  "initializationVector": "OmtDQdl6vkOI1GLKZSjgEg==",
+                  "publicKeyId": "tmtCidSRzR4fvNpLU5hMOM6FzamxJf0BBR8IkXIAwsY="
                 }
               }
             }
@@ -8370,7 +7580,7 @@
             }
           },
           "400": {
-            "description": "| ExceptionCode | ExceptionDescription | Details |\n|-|-|-|\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
+            "description": "| ExceptionCode       | ExceptionDescription                                                         | Details                                                | \n|---------------------|------------------------------------------------------------------------------|--------------------------------------------------------|\n| 21470               | Przesłany identyfikator klucza jest nieznany lub wskazuje na wycofany klucz. | Klucz o identyfikatorze {keyId} nie jest wspierany.    |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
             "content": {
               "application/json": {
                 "schema": {
@@ -8386,7 +7596,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | onlineSession\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | onlineSession\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -8435,9 +7645,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -8452,7 +7662,7 @@
           "Wysyłka interaktywna"
         ],
         "summary": "Wysłanie faktury",
-        "description": "Przyjmuje zaszyfrowaną fakturę oraz jej metadane i rozpoczyna jej przetwarzanie.\n\n> Więcej informacji:\n> - [Wysłanie faktury](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-interaktywna.md#2-wys%C5%82anie-faktury)\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Przyjmuje zaszyfrowaną fakturę oraz jej metadane i rozpoczyna jej przetwarzanie.\n\n> Więcej informacji:\n> - [Wysłanie faktury](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-interaktywna.md#2-wys%C5%82anie-faktury)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -8461,17 +7671,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -8535,7 +7734,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1800 | invoiceSend\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 180 | invoiceSend\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -8584,9 +7783,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1800
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 180
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -8601,7 +7800,7 @@
           "Wysyłka interaktywna"
         ],
         "summary": "Zamknięcie sesji interaktywnej",
-        "description": "Zamyka sesję interaktywną i rozpoczyna generowanie zbiorczego UPO dla sesji.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zamyka sesję interaktywną i rozpoczyna generowanie zbiorczego UPO dla sesji.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `PefInvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -8610,17 +7809,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -8645,7 +7833,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | onlineSession\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | onlineSession\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -8694,9 +7882,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -8711,20 +7899,7 @@
           "Wysyłka wsadowa"
         ],
         "summary": "Otwarcie sesji wsadowej",
-        "description": "Otwiera sesję do wysyłki wsadowej faktur. Należy przekazać schemat wysyłanych faktur, informacje o paczce faktur oraz informacje o kluczu używanym do szyfrowania.\n\n> Więcej informacji:\n> - [Przygotowanie paczki faktur](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-wsadowa.md)\n> - [Klucz publiczny Ministerstwa Finansów](/docs/v2/index.html#tag/Certyfikaty-klucza-publicznego)\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `EnforcementOperations`.",
-        "parameters": [
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Otwiera sesję do wysyłki wsadowej faktur. Należy przekazać schemat wysyłanych faktur, informacje o paczce faktur oraz informacje o kluczu używanym do szyfrowania.\n\n> Więcej informacji:\n> - [Przygotowanie paczki faktur](https://github.com/CIRFMF/ksef-docs/blob/main/sesja-wsadowa.md)\n> - [Klucz publiczny Ministerstwa Finansów](/docs/v2/index.html#tag/Certyfikaty-klucza-publicznego)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `EnforcementOperations`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8759,7 +7934,8 @@
                 },
                 "encryption": {
                   "encryptedSymmetricKey": "bYqmPAglF01AxZim4oNa+1NerhZYfFgLMnvksBprUur1aesQ0Y5jsmOIfCrozfMkF2tjdO+uOsBg4FPlDgjChwN2/tz2Hqwtxq3RkTr1SjY4x8jxJFpPedcS7EI+XO8C+i9mLj7TFx9p/bg07yM9vHtMAk5b88Ay9Qc3+T5Ch1DM2ClR3sVu2DqdlKzmbINY+rhfGtXn58Qo0XRyESGgc6M0iTZVBRPuPXLnD8a1KpOneCpNzLwxgT6Ei3ivLOpPWT53PxkRTaQ8puj6CIiCKo4FHQzHuI/NmrAhYU7TkNm2kymP/OxBgWdg3XB74tqNFfT8RZN1bZXuPhBidDOqa+xsqY3E871FSDmQwZf58HmoNl31XNvpnryiRGfnAISt+m+ELqgksAresVu6E9poUL1yiff+IOHSZABoYpNiqwnbT8qyW1uk8lKLyFVFu+kOsbzBk1OWWHqSkNFDaznDa2MKjHonOXI0uyKaKWvoBFC4dWN1PVumfpSSFAeYgNpAyVrZdcVOuiliEWepTDjGzJoOafTvwr5za2S6B5bPECDpX7JXazV7Olkq7ezG0w8y3olx+0C+NHoCk8B5/cm4gtVHTgKjiLSGpKJVOJABLXFkOyIOjbQsVe4ryX0Qy+SfL7JIQvTWvM5xkCoOMbzLdMo9tNo5qE34sguFI+lIevY=",
-                  "initializationVector": "jWpJLNBHJ5pQEGCBglmIAw=="
+                  "initializationVector": "jWpJLNBHJ5pQEGCBglmIAw==",
+                  "publicKeyId": "tmtCidSRzR4fvNpLU5hMOM6FzamxJf0BBR8IkXIAwsY="
                 },
                 "offlineMode": false
               }
@@ -8791,7 +7967,7 @@
             }
           },
           "400": {
-            "description": "| ExceptionCode       | ExceptionDescription                                | Details                                                                   | \n|---------------------|-----------------------------------------------------|---------------------------------------------------------------------------|\n| 21157               | Nieprawidłowy rozmiar części pakietu.               | {treść błędu walidacji}                                                   | \n| 21161               | Przekroczono dozwoloną liczbę części pakietu.       | {treść błędu walidacji}                                                   |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
+            "description": "| ExceptionCode       | ExceptionDescription                                                         | Details                                             | \n|---------------------|------------------------------------------------------------------------------|-----------------------------------------------------|\n| 21157               | Nieprawidłowy rozmiar części pakietu.                                        | {treść błędu walidacji}                             | \n| 21161               | Przekroczono dozwoloną liczbę części pakietu.                                | {treść błędu walidacji}                             |\n| 21470               | Przesłany identyfikator klucza jest nieznany lub wskazuje na wycofany klucz. | Klucz o identyfikatorze {keyId} nie jest wspierany. |\n| 21405 | Błąd walidacji danych wejściowych. | {treść błędu z walidatora} |",
             "content": {
               "application/json": {
                 "schema": {
@@ -8807,7 +7983,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 200 | 600 | batchSession\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 20 | 60 | batchSession\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -8856,9 +8032,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 200,
-          "perHour": 600
+          "perSecond": 10,
+          "perMinute": 20,
+          "perHour": 60
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -8872,7 +8048,7 @@
           "Wysyłka wsadowa"
         ],
         "summary": "Zamknięcie sesji wsadowej",
-        "description": "Zamyka sesję wsadową, rozpoczyna procesowanie paczki faktur i generowanie UPO dla prawidłowych faktur oraz zbiorczego UPO dla sesji.\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `EnforcementOperations`.",
+        "description": "Zamyka sesję wsadową, rozpoczyna procesowanie paczki faktur i generowanie UPO dla prawidłowych faktur oraz zbiorczego UPO dla sesji.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Wymagane uprawnienia**: `InvoiceWrite`, `EnforcementOperations`.",
         "parameters": [
           {
             "name": "referenceNumber",
@@ -8881,17 +8057,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/ReferenceNumber"
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -8916,7 +8081,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 200 | 600 | batchSession\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 20 | 60 | batchSession\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -8965,9 +8130,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 200,
-          "perHour": 600
+          "perSecond": 10,
+          "perMinute": 20,
+          "perHour": 60
         },
         "x-required-permissions": [
           "InvoiceWrite",
@@ -8981,7 +8146,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy własnych uprawnień",
-        "description": " Metoda pozwala na odczytanie własnych uprawnień uwierzytelnionego klienta API w bieżącym kontekście logowania.  \n\n W odpowiedzi przekazywane są następujące uprawnienia:  \n - nadane w sposób bezpośredni w bieżącym kontekście  \n - nadane przez podmiot nadrzędny  \n - nadane w sposób pośredni, jeżeli podmiot kontekstu logowania jest w uprawnieniu pośrednikiem lub podmiotem docelowym  \n - nadane podmiotowi do obsługi faktur przez inny podmiot, jeśli podmiot uwierzytelniony ma w bieżącym kontekście uprawnienia właścicielskie  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **CredentialsManage** – zarządzanie uprawnieniami  \n - **CredentialsRead** – przeglądanie uprawnień  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n - **SubunitManage** – zarządzanie podmiotami podrzędnymi  \n - **EnforcementOperations** – wykonywanie operacji egzekucyjnych  \n - **VatEuManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **contextIdentifier** – identyfikator podmiotu, który nadał uprawnienie do obsługi faktur  \n - **targetIdentifier** – identyfikator podmiotu docelowego dla uprawnień nadanych pośrednio  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n - **permissionState** – status uprawnienia  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-w%C5%82asnych-uprawnie%C5%84)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n",
+        "description": " Metoda pozwala na odczytanie własnych uprawnień uwierzytelnionego klienta API w bieżącym kontekście logowania.  \n\n W odpowiedzi przekazywane są następujące uprawnienia:  \n - nadane w sposób bezpośredni w bieżącym kontekście  \n - nadane przez podmiot nadrzędny  \n - nadane w sposób pośredni, jeżeli podmiot kontekstu logowania jest w uprawnieniu pośrednikiem lub podmiotem docelowym  \n - nadane podmiotowi do obsługi faktur przez inny podmiot, jeśli podmiot uwierzytelniony ma w bieżącym kontekście uprawnienia właścicielskie  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **CredentialsManage** – zarządzanie uprawnieniami  \n - **CredentialsRead** – przeglądanie uprawnień  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n - **SubunitManage** – zarządzanie podmiotami podrzędnymi  \n - **EnforcementOperations** – wykonywanie operacji egzekucyjnych  \n - **VatEuManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **contextIdentifier** – identyfikator podmiotu, który nadał uprawnienie do obsługi faktur  \n - **targetIdentifier** – identyfikator podmiotu docelowego dla uprawnień nadanych pośrednio  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n - **permissionState** – status uprawnienia  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-w%C5%82asnych-uprawnie%C5%84)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9004,17 +8169,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9090,7 +8244,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -9139,9 +8293,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -9161,7 +8315,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy uprawnień do pracy w KSeF nadanych osobom fizycznym lub podmiotom",
-        "description": " Metoda pozwala na odczytanie uprawnień nadanych osobie fizycznej lub podmiotowi.  \n Lista pobranych uprawnień może być dwóch rodzajów:  \n - Lista wszystkich uprawnień obowiązujących w bieżącym kontekście logowania (używana, gdy administrator chce przejrzeć uprawnienia wszystkich użytkowników w bieżącym kontekście)  \n - Lista wszystkich uprawnień nadanych w bieżącym kontekście przez uwierzytelnionego klienta API (używana, gdy administrator chce przejrzeć listę nadanych przez siebie uprawnień w bieżącym kontekście)  \n\n Dla pierwszej listy (obowiązujących uprawnień) w odpowiedzi przekazywane są:  \n - osoby i podmioty mogące pracować w bieżącym kontekście z wyjątkiem osób uprawnionych w sposób pośredni  \n - osoby uprawnione w sposób pośredni przez podmiot bieżącego kontekstu  \n\n Dla drugiej listy (nadanych uprawnień) w odpowiedzi przekazywane są:  \n - uprawnienia nadane w sposób bezpośredni do pracy w bieżącym kontekście lub w kontekście jednostek podrzędnych  \n - uprawnienia nadane w sposób pośredni do obsługi klientów podmiotu bieżącego kontekstu  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **CredentialsManage** – zarządzanie uprawnieniami  \n - **CredentialsRead** – przeglądanie uprawnień  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n - **SubunitManage** – zarządzanie podmiotami podrzędnymi  \n - **EnforcementOperations** – wykonywanie operacji egzekucyjnych  \n\n Odpowiedź może być filtrowana na podstawie parametrów:  \n - **authorIdentifier** – identyfikator osoby, która nadała uprawnienie  \n - **authorizedIdentifier** – identyfikator osoby lub podmiotu uprawnionego  \n - **targetIdentifier** – identyfikator podmiotu docelowego dla uprawnień nadanych pośrednio  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n - **permissionState** – status uprawnienia  \n - **queryType** – typ zapytania określający, która z dwóch list ma zostać zwrócona  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-do-pracy-w-ksef-nadanych-osobom-fizycznym-lub-podmiotom)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
+        "description": " Metoda pozwala na odczytanie uprawnień nadanych osobie fizycznej lub podmiotowi.  \n Lista pobranych uprawnień może być dwóch rodzajów:  \n - Lista wszystkich uprawnień obowiązujących w bieżącym kontekście logowania (używana, gdy administrator chce przejrzeć uprawnienia wszystkich użytkowników w bieżącym kontekście)  \n - Lista wszystkich uprawnień nadanych w bieżącym kontekście przez uwierzytelnionego klienta API (używana, gdy administrator chce przejrzeć listę nadanych przez siebie uprawnień w bieżącym kontekście)  \n\n Dla pierwszej listy (obowiązujących uprawnień) w odpowiedzi przekazywane są:  \n - osoby i podmioty mogące pracować w bieżącym kontekście z wyjątkiem osób uprawnionych w sposób pośredni  \n - osoby uprawnione w sposób pośredni przez podmiot bieżącego kontekstu  \n\n Dla drugiej listy (nadanych uprawnień) w odpowiedzi przekazywane są:  \n - uprawnienia nadane w sposób bezpośredni do pracy w bieżącym kontekście lub w kontekście jednostek podrzędnych  \n - uprawnienia nadane w sposób pośredni do obsługi klientów podmiotu bieżącego kontekstu  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **CredentialsManage** – zarządzanie uprawnieniami  \n - **CredentialsRead** – przeglądanie uprawnień  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n - **SubunitManage** – zarządzanie podmiotami podrzędnymi  \n - **EnforcementOperations** – wykonywanie operacji egzekucyjnych  \n\n Odpowiedź może być filtrowana na podstawie parametrów:  \n - **authorIdentifier** – identyfikator osoby, która nadała uprawnienie  \n - **authorizedIdentifier** – identyfikator osoby lub podmiotu uprawnionego  \n - **targetIdentifier** – identyfikator podmiotu docelowego dla uprawnień nadanych pośrednio  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n - **permissionState** – status uprawnienia  \n - **queryType** – typ zapytania określający, która z dwóch list ma zostać zwrócona  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-do-pracy-w-ksef-nadanych-osobom-fizycznym-lub-podmiotom)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9184,17 +8338,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9280,7 +8423,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -9329,9 +8472,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -9356,7 +8499,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy uprawnień administratorów jednostek i podmiotów podrzędnych",
-        "description": " Metoda pozwala na odczytanie uprawnień do zarządzania uprawnieniami nadanych administratorom:  \n - jednostek podrzędnych identyfikowanych identyfikatorem wewnętrznym  \n - podmiotów podrzędnych (podrzędnych JST lub członków grupy VAT) identyfikowanych przez NIP  \n\n Lista zwraca wyłącznie uprawnienia do zarządzania uprawnieniami nadane z kontekstu bieżącego (z podmiotu nadrzędnego).  \n Nie są odczytywane uprawnienia nadane przez administratorów jednostek podrzędnych wewnątrz tych jednostek.  \n\n Odpowiedź może być filtrowana na podstawie parametru:  \n - **subunitIdentifier** – identyfikator jednostki lub podmiotu podrzędnego  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-administrator%C3%B3w-jednostek-i-podmiot%C3%B3w-podrz%C4%99dnych)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
+        "description": " Metoda pozwala na odczytanie uprawnień do zarządzania uprawnieniami nadanych administratorom:  \n - jednostek podrzędnych identyfikowanych identyfikatorem wewnętrznym  \n - podmiotów podrzędnych (podrzędnych JST lub członków grupy VAT) identyfikowanych przez NIP  \n\n Lista zwraca wyłącznie uprawnienia do zarządzania uprawnieniami nadane z kontekstu bieżącego (z podmiotu nadrzędnego).  \n Nie są odczytywane uprawnienia nadane przez administratorów jednostek podrzędnych wewnątrz tych jednostek.  \n\n Odpowiedź może być filtrowana na podstawie parametru:  \n - **subunitIdentifier** – identyfikator jednostki lub podmiotu podrzędnego  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-administrator%C3%B3w-jednostek-i-podmiot%C3%B3w-podrz%C4%99dnych)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9379,17 +8522,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9463,7 +8595,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -9512,9 +8644,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -9539,7 +8671,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy uprawnień do obsługi faktur w bieżącym kontekście",
-        "description": " Metoda pozwala na odczytanie otrzymanych uprawnień do obsługi faktur w bieżącym kontekście logowania.  \n\n W odpowiedzi przekazywane są następujące uprawnienia:  \n - nadane podmiotowi do obsługi faktur przez inny podmiot \n\n Uprawnienia zwracane przez operację obejmują:  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **contextIdentifier** – identyfikator podmiotu, który nadał uprawnienie do obsługi faktur  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-do-obs%C5%82ugi-faktur-w-bie%C5%BC%C4%85cym-kontek%C5%9Bcie)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
+        "description": " Metoda pozwala na odczytanie otrzymanych uprawnień do obsługi faktur w bieżącym kontekście logowania.  \n\n W odpowiedzi przekazywane są następujące uprawnienia:  \n - nadane podmiotowi do obsługi faktur przez inny podmiot \n\n Uprawnienia zwracane przez operację obejmują:  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **contextIdentifier** – identyfikator podmiotu, który nadał uprawnienie do obsługi faktur  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-do-obs%C5%82ugi-faktur-w-bie%C5%BC%C4%85cym-kontek%C5%9Bcie)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9562,17 +8694,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9639,7 +8760,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -9688,9 +8809,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -9714,7 +8835,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy ról podmiotu",
-        "description": " Metoda pozwala na **odczytanie listy ról podmiotu bieżącego kontekstu logowania**.\n\n#### Role podmiotów zwracane przez operację:\n- **CourtBailiff** – komornik sądowy  \n- **EnforcementAuthority** – organ egzekucyjny  \n- **LocalGovernmentUnit** – nadrzędna JST  \n- **LocalGovernmentSubUnit** – podrzędne JST  \n- **VatGroupUnit** – grupa VAT  \n- **VatGroupSubUnit** – członek grupy VAT\n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n \n > Więcej informacji:\n > - [Pobieranie listy ról](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-r%C3%B3l-podmiotu)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
+        "description": " Metoda pozwala na **odczytanie listy ról podmiotu bieżącego kontekstu logowania**.\n\n#### Role podmiotów zwracane przez operację:\n- **CourtBailiff** – komornik sądowy  \n- **EnforcementAuthority** – organ egzekucyjny  \n- **LocalGovernmentUnit** – nadrzędna JST  \n- **LocalGovernmentSubUnit** – podrzędne JST  \n- **VatGroupUnit** – grupa VAT  \n- **VatGroupSubUnit** – członek grupy VAT\n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n \n > Więcej informacji:\n > - [Pobieranie listy ról](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-r%C3%B3l-podmiotu)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9737,17 +8858,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9789,7 +8899,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -9838,9 +8948,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -9864,7 +8974,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy podmiotów podrzędnych",
-        "description": " Metoda pozwala na odczytanie listy podmiotów podrzędnych,  \n jeżeli podmiot bieżącego kontekstu ma rolę podmiotu nadrzędnego:\n - **nadrzędna JST** – odczytywane są podrzędne JST,  \n - **grupa VAT** – odczytywane są podmioty będące członkami grupy VAT.\n\n Role podmiotów zwracane przez operację obejmują:  \n - **LocalGovernmentSubUnit** – podrzędne JST,  \n - **VatGroupSubUnit** – członek grupy VAT.\n\n Odpowiedź może być filtrowana według parametru:  \n - **subordinateEntityIdentifier** – identyfikator podmiotu podrzędnego.\n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n  \n > Więcej informacji:\n > - [Pobieranie listy podmiotów podrzędnych](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-podmiot%C3%B3w-podrz%C4%99dnych)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
+        "description": " Metoda pozwala na odczytanie listy podmiotów podrzędnych,  \n jeżeli podmiot bieżącego kontekstu ma rolę podmiotu nadrzędnego:\n - **nadrzędna JST** – odczytywane są podrzędne JST,  \n - **grupa VAT** – odczytywane są podmioty będące członkami grupy VAT.\n\n Role podmiotów zwracane przez operację obejmują:  \n - **LocalGovernmentSubUnit** – podrzędne JST,  \n - **VatGroupSubUnit** – członek grupy VAT.\n\n Odpowiedź może być filtrowana według parametru:  \n - **subordinateEntityIdentifier** – identyfikator podmiotu podrzędnego.\n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n  \n > Więcej informacji:\n > - [Pobieranie listy podmiotów podrzędnych](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-podmiot%C3%B3w-podrz%C4%99dnych)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `SubunitManage`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -9887,17 +8997,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -9962,7 +9061,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -10011,9 +9110,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -10038,7 +9137,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy uprawnień podmiotowych do obsługi faktur",
-        "description": " Metoda pozwala na odczytanie uprawnień podmiotowych:  \n - otrzymanych przez podmiot bieżącego kontekstu  \n - nadanych przez podmiot bieżącego kontekstu  \n\n Wybór listy nadanych lub otrzymanych uprawnień odbywa się przy użyciu parametru **queryType**.  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **SelfInvoicing** – wystawianie faktur w trybie samofakturowania  \n - **TaxRepresentative** – wykonywanie operacji przedstawiciela podatkowego  \n - **RRInvoicing** – wystawianie faktur VAT RR  \n - **PefInvoicing** – wystawianie faktur PEF  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **authorizingIdentifier** – identyfikator podmiotu uprawniającego (stosowane przy queryType = Received)  \n - **authorizedIdentifier** – identyfikator podmiotu uprawnionego (stosowane przy queryType = Granted)  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-podmiotowych-do-obs%C5%82ugi-faktur)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `PefInvoiceWrite`.",
+        "description": " Metoda pozwala na odczytanie uprawnień podmiotowych:  \n - otrzymanych przez podmiot bieżącego kontekstu  \n - nadanych przez podmiot bieżącego kontekstu  \n\n Wybór listy nadanych lub otrzymanych uprawnień odbywa się przy użyciu parametru **queryType**.  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **SelfInvoicing** – wystawianie faktur w trybie samofakturowania  \n - **TaxRepresentative** – wykonywanie operacji przedstawiciela podatkowego  \n - **RRInvoicing** – wystawianie faktur VAT RR  \n - **PefInvoicing** – wystawianie faktur PEF  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **authorizingIdentifier** – identyfikator podmiotu uprawniającego (stosowane przy queryType = Received)  \n - **authorizedIdentifier** – identyfikator podmiotu uprawnionego (stosowane przy queryType = Granted)  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n\n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-podmiotowych-do-obs%C5%82ugi-faktur)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `PefInvoiceWrite`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -10061,17 +9160,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -10154,7 +9242,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -10203,9 +9291,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -10230,7 +9318,7 @@
           "Wyszukiwanie nadanych uprawnień"
         ],
         "summary": "Pobranie listy uprawnień administratorów lub reprezentantów podmiotów unijnych uprawnionych do samofakturowania",
-        "description": " Metoda pozwala na odczytanie uprawnień administratorów lub reprezentantów podmiotów unijnych:  \n - Jeżeli kontekstem logowania jest NIP, możliwe jest odczytanie uprawnień administratorów podmiotów unijnych powiązanych z podmiotem bieżącego kontekstu, czyli takich, dla których pierwszy człon kontekstu złożonego jest równy NIP-owi kontekstu logowania.  \n - Jeżeli kontekst logowania jest złożony (NIP-VAT UE), możliwe jest pobranie wszystkich uprawnień administratorów i reprezentantów podmiotu w bieżącym kontekście złożonym.  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **VatUeManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **vatUeIdentifier** – identyfikator podmiotu unijnego  \n - **authorizedFingerprintIdentifier** – odcisk palca certyfikatu uprawnionej osoby lub podmiotu  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n \n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-administrator%C3%B3w-lub-reprezentant%C3%B3w-podmiot%C3%B3w-unijnych-uprawnionych-do-samofakturowania)\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `VatUeManage`.",
+        "description": " Metoda pozwala na odczytanie uprawnień administratorów lub reprezentantów podmiotów unijnych:  \n - Jeżeli kontekstem logowania jest NIP, możliwe jest odczytanie uprawnień administratorów podmiotów unijnych powiązanych z podmiotem bieżącego kontekstu, czyli takich, dla których pierwszy człon kontekstu złożonego jest równy NIP-owi kontekstu logowania.  \n - Jeżeli kontekst logowania jest złożony (NIP-VAT UE), możliwe jest pobranie wszystkich uprawnień administratorów i reprezentantów podmiotu w bieżącym kontekście złożonym.  \n\n Uprawnienia zwracane przez operację obejmują:  \n - **VatUeManage** – zarządzanie uprawnieniami w ramach podmiotu unijnego  \n - **InvoiceWrite** – wystawianie faktur  \n - **InvoiceRead** – przeglądanie faktur  \n - **Introspection** – przeglądanie historii sesji  \n\n Odpowiedź może być filtrowana na podstawie następujących parametrów:  \n - **vatUeIdentifier** – identyfikator podmiotu unijnego  \n - **authorizedFingerprintIdentifier** – odcisk palca certyfikatu uprawnionej osoby lub podmiotu  \n - **permissionTypes** – lista rodzajów wyszukiwanych uprawnień  \n\n#### Stronicowanie wyników\nZapytanie zwraca **jedną stronę wyników** o numerze i rozmiarze podanym w ścieżce.\n- Przy pierwszym wywołaniu należy ustawić parametr `pageOffset = 0`.  \n- Jeżeli dostępna jest kolejna strona wyników, w odpowiedzi pojawi się flaga **`hasMore`**.  \n- W takim przypadku można wywołać zapytanie ponownie z kolejnym numerem strony.\n \n > Więcej informacji:\n > - [Pobieranie listy uprawnień](https://github.com/CIRFMF/ksef-docs/blob/main/uprawnienia.md#pobranie-listy-uprawnie%C5%84-administrator%C3%B3w-lub-reprezentant%C3%B3w-podmiot%C3%B3w-unijnych-uprawnionych-do-samofakturowania)\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).\n\n**Sortowanie:**\n\n- startDate (Desc)\n- id (Asc)\n\n\n\n**Wymagane uprawnienia**: `CredentialsManage`, `CredentialsRead`, `VatUeManage`.",
         "parameters": [
           {
             "name": "pageOffset",
@@ -10253,17 +9341,6 @@
               "type": "integer",
               "format": "int32",
               "default": 10
-            }
-          },
-          {
-            "name": "X-Error-Format",
-            "in": "header",
-            "description": "Opcjonalny nagłówek przełączający format błędów na Problem Details",
-            "schema": {
-              "enum": [
-                "problem-details"
-              ],
-              "type": "string"
             }
           }
         ],
@@ -10333,7 +9410,7 @@
             "x-summary": "Bad Request"
           },
           "429": {
-            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 100 | 300 | 1200 | other\n",
+            "description": "| | req / s | req / min | req / h | grupa\n| --- | --- | --- | --- | --- |\n| **Limity liczby żądań** | 10 | 30 | 120 | other\n",
             "headers": {
               "Retry-After": {
                 "schema": {
@@ -10382,9 +9459,9 @@
           }
         ],
         "x-rate-limits": {
-          "perSecond": 100,
-          "perMinute": 300,
-          "perHour": 1200
+          "perSecond": 10,
+          "perMinute": 30,
+          "perHour": 120
         },
         "x-sort": [
           {
@@ -11379,6 +10456,9 @@
             "description": "Informacje o aktualnym statusie.\n| Code | Description | Details |\n| --- | --- | --- |\n| 100 | Wniosek przyjęty do realizacji | - |\n| 200 | Wniosek obsłużony (certyfikat wygenerowany) | - |\n| 400 | Wniosek odrzucony | Klucz publiczny został już certyfikowany przez inny podmiot. |\n| 400 | Wniosek odrzucony | Osiągnięto dopuszczalny limit posiadanych certyfikatów. |\n| 500 | Nieznany błąd | - |\n| 550 | Operacja została anulowana przez system | Przetwarzanie zostało przerwane z przyczyn wewnętrznych systemu. Spróbuj ponownie |"
           },
           "certificateSerialNumber": {
+            "maxLength": 16,
+            "minLength": 16,
+            "pattern": "^[0-9A-F]{16}$",
             "type": "string",
             "description": "Numer seryjny wygenerowanego certyfikatu (w formacie szesnastkowym). \nZwracany w przypadku prawidłowego przeprocesowania wniosku certyfikacyjnego.",
             "nullable": true
@@ -11459,6 +10539,9 @@
         "type": "object",
         "properties": {
           "certificateSerialNumber": {
+            "maxLength": 16,
+            "minLength": 16,
+            "pattern": "^[0-9A-F]{16}$",
             "type": "string",
             "description": "Numer seryjny certyfikatu (w formacie szesnastkowym)."
           },
@@ -12074,6 +11157,14 @@
             "type": "string",
             "description": "Wektor inicjalizujący (IV) o długości 16 bajtów, używany do szyfrowania symetrycznego, zakodowany w formacie Base64.",
             "format": "byte"
+          },
+          "publicKeyId": {
+            "maxLength": 44,
+            "minLength": 44,
+            "type": "string",
+            "description": "Identyfikator klucza publicznego użytego do szyfrowania.",
+            "format": "byte",
+            "nullable": true
           }
         }
       },
@@ -13806,6 +12897,14 @@
             "description": "Zaszyfrowany token wraz z timestampem z challenge'a, w postaci `token|timestamp`, zakodowany w formacie Base64.",
             "format": "byte"
           },
+          "publicKeyId": {
+            "maxLength": 44,
+            "minLength": 44,
+            "type": "string",
+            "description": "Identyfikator klucza publicznego użytego do szyfrowania tokena.",
+            "format": "byte",
+            "nullable": true
+          },
           "authorizationPolicy": {
             "allOf": [
               {
@@ -14031,7 +13130,7 @@
                 "$ref": "#/components/schemas/FormCode"
               }
             ],
-            "description": "Struktura dokumentu faktury.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value | ValidFrom | ValidTo |\n| --- | --- | --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [PEF (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF(3)_v2-1.xsd) | 2-1 | PEF |  |  |\n| [PEF_KOR (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF_KOR(3)_v2-1.xsd) | 2-1 | PEF |  |  |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-0E.xsd) | 1-0E | RR |  | 23.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-1E.xsd) | 1-1E | RR |  | 30.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |  |  |\n"
+            "description": "Struktura dokumentu faktury.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value |\n| --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |\n| [PEF (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF(3)_v2-1.xsd) | 2-1 | PEF |\n| [PEF_KOR (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF_KOR(3)_v2-1.xsd) | 2-1 | PEF |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |\n"
           },
           "isSelfInvoicing": {
             "type": "boolean",
@@ -14556,7 +13655,7 @@
                 "$ref": "#/components/schemas/InvoiceQueryFormType"
               }
             ],
-            "description": "Typ dokumentu.\n| Wartość | Opis |\n| --- | --- |\n| FA | Faktura VAT |\n| PEF | Faktura PEF |\n| RR ![Deprecated](https://img.shields.io/badge/Deprecated-orange) | Faktura RR |\n| FA_RR | Faktura RR |\n",
+            "description": "Typ dokumentu.\n| Wartość | Opis |\n| --- | --- |\n| FA | Faktura VAT |\n| PEF | Faktura PEF |\n| FA_RR | Faktura RR |\n",
             "nullable": true
           },
           "invoiceTypes": {
@@ -14581,7 +13680,7 @@
           "FA_RR"
         ],
         "type": "string",
-        "description": "| Wartość | Opis |\n| --- | --- |\n| FA | Faktura VAT |\n| PEF | Faktura PEF |\n| RR ![Deprecated](https://img.shields.io/badge/Deprecated-orange) | Faktura RR |\n| FA_RR | Faktura RR |\n"
+        "description": "| Wartość | Opis |\n| --- | --- |\n| FA | Faktura VAT |\n| PEF | Faktura PEF |\n| FA_RR | Faktura RR |\n"
       },
       "InvoiceQuerySubjectType": {
         "enum": [
@@ -14759,7 +13858,7 @@
                 "$ref": "#/components/schemas/FormCode"
               }
             ],
-            "description": "Schemat faktur wysyłanych w ramach sesji.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value | ValidFrom | ValidTo |\n| --- | --- | --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-0E.xsd) | 1-0E | RR |  | 23.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-1E.xsd) | 1-1E | RR |  | 30.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |  |  |\n"
+            "description": "Schemat faktur wysyłanych w ramach sesji.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value |\n| --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |\n"
           },
           "batchFile": {
             "required": [
@@ -14835,7 +13934,7 @@
                 "$ref": "#/components/schemas/FormCode"
               }
             ],
-            "description": "Schemat faktur wysyłanych w ramach sesji.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value | ValidFrom | ValidTo |\n| --- | --- | --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |  |  |\n| [PEF (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF(3)_v2-1.xsd) | 2-1 | PEF |  |  |\n| [PEF_KOR (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF_KOR(3)_v2-1.xsd) | 2-1 | PEF |  |  |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-0E.xsd) | 1-0E | RR |  | 23.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_RR(1)_v1-1E.xsd) | 1-1E | RR |  | 30.03.2026 |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |  |  |\n"
+            "description": "Schemat faktur wysyłanych w ramach sesji.\n\nObsługiwane schematy:\n| SystemCode | SchemaVersion | Value |\n| --- | --- | --- |\n| [FA (2)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(2)_v1-0E.xsd) | 1-0E | FA |\n| [FA (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/FA/schemat_FA(3)_v1-0E.xsd) | 1-0E | FA |\n| [PEF (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF(3)_v2-1.xsd) | 2-1 | PEF |\n| [PEF_KOR (3)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/PEF/Schemat_PEF_KOR(3)_v2-1.xsd) | 2-1 | PEF |\n| [FA_RR (1)](https://github.com/CIRFMF/ksef-docs/blob/main/faktury/schemy/RR/schemat_FA_RR(1)_v1-1E.xsd) | 1-1E | FA_RR |\n"
           },
           "encryption": {
             "required": [
@@ -16211,6 +15310,8 @@
       "PublicKeyCertificate": {
         "required": [
           "certificate",
+          "certificateId",
+          "publicKeyId",
           "usage",
           "validFrom",
           "validTo"
@@ -16220,6 +15321,16 @@
           "certificate": {
             "type": "string",
             "description": "Certyfikat klucza publicznego w formacie DER, zakodowany w formacie Base64.",
+            "format": "byte"
+          },
+          "certificateId": {
+            "type": "string",
+            "description": "Identyfikator certyfikatu.",
+            "format": "byte"
+          },
+          "publicKeyId": {
+            "type": "string",
+            "description": "Identyfikator klucza, używany jako selektor w wywołaniach, w których klient wskazuje, jakiego klucza publicznego użył do szyfrowania.",
             "format": "byte"
           },
           "validFrom": {
@@ -16253,6 +15364,9 @@
         "type": "object",
         "properties": {
           "certificateSerialNumber": {
+            "maxLength": 16,
+            "minLength": 16,
+            "pattern": "^[0-9A-F]{16}$",
             "type": "string",
             "description": "Numer seryjny certyfikatu. Wyszukiwanie odbywa się na zasadzie dokładnego dopasowania (exact match).",
             "nullable": true
@@ -16657,6 +15771,9 @@
             "description": "Nazwa własna certyfikatu."
           },
           "certificateSerialNumber": {
+            "maxLength": 16,
+            "minLength": 16,
+            "pattern": "^[0-9A-F]{16}$",
             "type": "string",
             "description": "Numer seryjny certyfikatu."
           },
@@ -16681,6 +15798,9 @@
             "minItems": 1,
             "type": "array",
             "items": {
+              "maxLength": 16,
+              "minLength": 16,
+              "pattern": "^[0-9A-F]{16}$",
               "type": "string"
             },
             "description": "Numery seryjne certyfikatów do pobrania."

--- a/src/ksef_client/cli/auth/manager.py
+++ b/src/ksef_client/cli/auth/manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +16,12 @@ from ..exit_codes import ExitCode
 from ..sdk.factory import create_client
 from .keyring_store import clear_tokens, get_tokens, save_tokens
 from .token_cache import clear_cached_metadata, get_cached_metadata, set_cached_metadata
+
+
+@dataclass(frozen=True)
+class SelectedPublicKeyCertificate:
+    certificate: str
+    public_key_id: str | None = None
 
 
 def _extract_ksef_token_reference_number(token: str) -> str | None:
@@ -87,7 +95,46 @@ def _collect_active_token_reference_numbers(
     return matched_references
 
 
-def _select_certificate(certs: list[Any], usage_name: str) -> str:
+def _parse_certificate_datetime(value: Any) -> datetime | None:
+    if value in {None, ""}:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_current_certificate(cert: Any, now: datetime) -> bool:
+    if isinstance(cert, dict):
+        valid_from_raw = cert.get("validFrom")
+        valid_to_raw = cert.get("validTo")
+    else:
+        valid_from_raw = getattr(cert, "valid_from", None)
+        valid_to_raw = getattr(cert, "valid_to", None)
+    valid_from = _parse_certificate_datetime(valid_from_raw)
+    valid_to = _parse_certificate_datetime(valid_to_raw)
+    if valid_from is not None and valid_from > now:
+        return False
+    return not (valid_to is not None and valid_to < now)
+
+
+def _certificate_sort_key(cert: Any) -> tuple[bool, datetime]:
+    if isinstance(cert, dict):
+        valid_from_raw = cert.get("validFrom")
+    else:
+        valid_from_raw = getattr(cert, "valid_from", None)
+    valid_from = _parse_certificate_datetime(valid_from_raw)
+    if valid_from is None:
+        return (False, datetime.min.replace(tzinfo=timezone.utc))
+    return (True, valid_from)
+
+
+def _select_certificate(certs: list[Any], usage_name: str) -> SelectedPublicKeyCertificate:
+    now = datetime.now(timezone.utc)
+    candidates = []
     for cert in certs:
         if isinstance(cert, dict):
             usage = cert.get("usage")
@@ -98,8 +145,20 @@ def _select_certificate(certs: list[Any], usage_name: str) -> str:
         usage_values = (
             [str(getattr(item, "value", item)) for item in usage] if isinstance(usage, list) else []
         )
-        if usage_name in usage_values and certificate:
-            return str(certificate)
+        if usage_name in usage_values and certificate and _is_current_certificate(cert, now):
+            candidates.append(cert)
+    if candidates:
+        selected = max(candidates, key=_certificate_sort_key)
+        if isinstance(selected, dict):
+            certificate = selected.get("certificate")
+            public_key_id = selected.get("publicKeyId")
+        else:
+            certificate = getattr(selected, "certificate", None)
+            public_key_id = getattr(selected, "public_key_id", None)
+        return SelectedPublicKeyCertificate(
+            certificate=str(certificate),
+            public_key_id=str(public_key_id) if public_key_id is not None else None,
+        )
     raise CliError(
         f"Missing KSeF public certificate usage: {usage_name}.",
         ExitCode.API_ERROR,
@@ -184,7 +243,7 @@ def login_with_token(
         token_cert_pem = _select_certificate(certs, "KsefTokenEncryption")
         result = AuthCoordinator(client.auth).authenticate_with_ksef_token(
             token=safe_token,
-            public_certificate=token_cert_pem,
+            public_certificate=token_cert_pem.certificate,
             context_identifier_type=safe_context_type,
             context_identifier_value=safe_context_value,
             poll_interval_seconds=poll_interval,

--- a/src/ksef_client/cli/auth/manager.py
+++ b/src/ksef_client/cli/auth/manager.py
@@ -244,6 +244,7 @@ def login_with_token(
         result = AuthCoordinator(client.auth).authenticate_with_ksef_token(
             token=safe_token,
             public_certificate=token_cert_pem.certificate,
+            public_key_id=token_cert_pem.public_key_id,
             context_identifier_type=safe_context_type,
             context_identifier_value=safe_context_value,
             poll_interval_seconds=poll_interval,

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -1271,6 +1271,7 @@ def send_online_invoice(
         session = workflow.open_session(
             form_code=form_code,
             public_certificate=symmetric_cert.certificate,
+            public_key_id=symmetric_cert.public_key_id,
             access_token=access_token,
             upo_v43=upo_v43,
         )
@@ -1444,6 +1445,7 @@ def send_batch_invoices(
                 form_code=form_code,
                 zip_bytes=zip_bytes,
                 public_certificate=symmetric_cert.certificate,
+                public_key_id=symmetric_cert.public_key_id,
                 access_token=access_token,
                 upo_v43=upo_v43,
                 parallelism=parallelism,
@@ -1453,6 +1455,7 @@ def send_batch_invoices(
                 form_code=form_code,
                 zip_bytes=zip_bytes,
                 public_certificate=symmetric_cert.certificate,
+                public_key_id=symmetric_cert.public_key_id,
                 access_token=access_token,
                 upo_v43=upo_v43,
             )
@@ -1619,13 +1622,13 @@ def run_export(
     with create_client(base_url, access_token=access_token) as client:
         certs = client.security.get_public_key_certificates()
         symmetric_cert = _select_certificate(certs, "SymmetricKeyEncryption")
-        encryption = build_encryption_data(symmetric_cert.certificate)
+        encryption = build_encryption_data(
+            symmetric_cert.certificate,
+            public_key_id=symmetric_cert.public_key_id,
+        )
         encryption_info = _require_encryption_info(encryption)
         payload = m.InvoiceExportRequest(
-            encryption=m.EncryptionInfo(
-                encrypted_symmetric_key=encryption_info.encrypted_symmetric_key,
-                initialization_vector=encryption_info.initialization_vector,
-            ),
+            encryption=encryption_info,
             only_metadata=only_metadata,
             filters=m.InvoiceQueryFilters(
                 subject_type=_require_invoice_query_subject_type(subject_type),

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -4,6 +4,7 @@ import calendar
 import json
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
@@ -49,6 +50,12 @@ _INVOICE_SORT_DATE_FIELDS = {
         ("permanent_storage_date", "permanentStorageDate"),
     ),
 }
+
+
+@dataclass(frozen=True)
+class SelectedPublicKeyCertificate:
+    certificate: str
+    public_key_id: str | None = None
 
 
 def _is_transient_polling_http(status_code: int) -> bool:
@@ -247,12 +254,48 @@ def _extract_upo_reference(payload: Any) -> str:
     return str(nested or "")
 
 
-def _select_certificate(certs: list[Any], usage_name: str) -> str:
+def _parse_certificate_datetime(value: Any) -> datetime | None:
+    if value in {None, ""}:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_current_certificate(cert: Any, now: datetime) -> bool:
+    valid_from = _parse_certificate_datetime(_get_value(cert, "valid_from", "validFrom"))
+    valid_to = _parse_certificate_datetime(_get_value(cert, "valid_to", "validTo"))
+    if valid_from is not None and valid_from > now:
+        return False
+    return not (valid_to is not None and valid_to < now)
+
+
+def _certificate_sort_key(cert: Any) -> tuple[bool, datetime]:
+    valid_from = _parse_certificate_datetime(_get_value(cert, "valid_from", "validFrom"))
+    if valid_from is None:
+        return (False, datetime.min.replace(tzinfo=timezone.utc))
+    return (True, valid_from)
+
+
+def _select_certificate(certs: list[Any], usage_name: str) -> SelectedPublicKeyCertificate:
+    now = datetime.now(timezone.utc)
+    candidates = []
     for cert in certs:
         usage = _as_string_list(_get_value(cert, "usage", default=[]))
         certificate = _get_value(cert, "certificate")
-        if usage_name in usage and certificate:
-            return str(certificate)
+        if usage_name in usage and certificate and _is_current_certificate(cert, now):
+            candidates.append(cert)
+    if candidates:
+        selected = max(candidates, key=_certificate_sort_key)
+        public_key_id = _get_value(selected, "public_key_id", "publicKeyId")
+        return SelectedPublicKeyCertificate(
+            certificate=str(_get_value(selected, "certificate")),
+            public_key_id=str(public_key_id) if public_key_id is not None else None,
+        )
     raise CliError(
         f"Missing KSeF public certificate usage: {usage_name}.",
         ExitCode.API_ERROR,
@@ -1227,7 +1270,7 @@ def send_online_invoice(
 
         session = workflow.open_session(
             form_code=form_code,
-            public_certificate=symmetric_cert,
+            public_certificate=symmetric_cert.certificate,
             access_token=access_token,
             upo_v43=upo_v43,
         )
@@ -1400,7 +1443,7 @@ def send_batch_invoices(
             session_ref = workflow.open_upload_and_close(
                 form_code=form_code,
                 zip_bytes=zip_bytes,
-                public_certificate=symmetric_cert,
+                public_certificate=symmetric_cert.certificate,
                 access_token=access_token,
                 upo_v43=upo_v43,
                 parallelism=parallelism,
@@ -1409,7 +1452,7 @@ def send_batch_invoices(
             session = workflow.open_session(
                 form_code=form_code,
                 zip_bytes=zip_bytes,
-                public_certificate=symmetric_cert,
+                public_certificate=symmetric_cert.certificate,
                 access_token=access_token,
                 upo_v43=upo_v43,
             )
@@ -1576,7 +1619,7 @@ def run_export(
     with create_client(base_url, access_token=access_token) as client:
         certs = client.security.get_public_key_certificates()
         symmetric_cert = _select_certificate(certs, "SymmetricKeyEncryption")
-        encryption = build_encryption_data(symmetric_cert)
+        encryption = build_encryption_data(symmetric_cert.certificate)
         encryption_info = _require_encryption_info(encryption)
         payload = m.InvoiceExportRequest(
             encryption=m.EncryptionInfo(

--- a/src/ksef_client/cli/sdk/session_ops.py
+++ b/src/ksef_client/cli/sdk/session_ops.py
@@ -198,7 +198,7 @@ def open_online_session(
         workflow = OnlineSessionWorkflow(client.sessions)
         session = workflow.open_session(
             form_code=form_code,
-            public_certificate=symmetric_cert,
+            public_certificate=symmetric_cert.certificate,
             access_token=access_token,
             upo_v43=upo_v43,
         )
@@ -368,7 +368,7 @@ def open_batch_session(
         session = workflow.open_session(
             form_code=form_code,
             zip_bytes=zip_bytes,
-            public_certificate=symmetric_cert,
+            public_certificate=symmetric_cert.certificate,
             access_token=access_token,
             upo_v43=upo_v43,
         )

--- a/src/ksef_client/cli/sdk/session_ops.py
+++ b/src/ksef_client/cli/sdk/session_ops.py
@@ -199,6 +199,7 @@ def open_online_session(
         session = workflow.open_session(
             form_code=form_code,
             public_certificate=symmetric_cert.certificate,
+            public_key_id=symmetric_cert.public_key_id,
             access_token=access_token,
             upo_v43=upo_v43,
         )
@@ -369,6 +370,7 @@ def open_batch_session(
             form_code=form_code,
             zip_bytes=zip_bytes,
             public_certificate=symmetric_cert.certificate,
+            public_key_id=symmetric_cert.public_key_id,
             access_token=access_token,
             upo_v43=upo_v43,
         )

--- a/src/ksef_client/clients/security.py
+++ b/src/ksef_client/clients/security.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from ..models import PublicKeyCertificate, PublicKeyCertificateUsage
 from .base import AsyncBaseApiClient, BaseApiClient
 
@@ -19,6 +21,53 @@ def _normalize_certificate_usage(
     raise ValueError(f"Unsupported public key certificate usage: {usage}")
 
 
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_current_certificate(certificate: PublicKeyCertificate, now: datetime) -> bool:
+    valid_from = _parse_datetime(certificate.valid_from)
+    valid_to = _parse_datetime(certificate.valid_to)
+    if valid_from is not None and valid_from > now:
+        return False
+    return not (valid_to is not None and valid_to < now)
+
+
+def _certificate_sort_key(certificate: PublicKeyCertificate) -> tuple[bool, datetime]:
+    valid_from = _parse_datetime(certificate.valid_from)
+    if valid_from is None:
+        return (False, datetime.min.replace(tzinfo=timezone.utc))
+    return (True, valid_from)
+
+
+def _select_public_key_certificate(
+    certificates: list[PublicKeyCertificate],
+    usage: PublicKeyCertificateUsage | str,
+    *,
+    now: datetime | None = None,
+) -> PublicKeyCertificate:
+    normalized_usage = _normalize_certificate_usage(usage)
+    current_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    candidates = [
+        certificate
+        for certificate in certificates
+        if normalized_usage in certificate.usage
+        and certificate.certificate
+        and _is_current_certificate(certificate, current_now)
+    ]
+    if not candidates:
+        raise ValueError(f"Missing KSeF public certificate for usage: {normalized_usage.value}")
+    return max(candidates, key=_certificate_sort_key)
+
+
 class SecurityClient(BaseApiClient):
     def get_public_key_certificates(self) -> list[PublicKeyCertificate]:
         return self._request_model_list(
@@ -32,11 +81,7 @@ class SecurityClient(BaseApiClient):
         self,
         usage: PublicKeyCertificateUsage | str,
     ) -> PublicKeyCertificate:
-        normalized_usage = _normalize_certificate_usage(usage)
-        for certificate in self.get_public_key_certificates():
-            if normalized_usage in certificate.usage:
-                return certificate
-        raise ValueError(f"Missing KSeF public certificate for usage: {normalized_usage.value}")
+        return _select_public_key_certificate(self.get_public_key_certificates(), usage)
 
     def get_public_key_certificate_pem(
         self,
@@ -58,11 +103,7 @@ class AsyncSecurityClient(AsyncBaseApiClient):
         self,
         usage: PublicKeyCertificateUsage | str,
     ) -> PublicKeyCertificate:
-        normalized_usage = _normalize_certificate_usage(usage)
-        for certificate in await self.get_public_key_certificates():
-            if normalized_usage in certificate.usage:
-                return certificate
-        raise ValueError(f"Missing KSeF public certificate for usage: {normalized_usage.value}")
+        return _select_public_key_certificate(await self.get_public_key_certificates(), usage)
 
     async def get_public_key_certificate_pem(
         self,

--- a/src/ksef_client/models.py
+++ b/src/ksef_client/models.py
@@ -408,6 +408,8 @@ class LighthouseStatusResponse:
 class PublicKeyCertificate:
     certificate: str
     usage: list[PublicKeyCertificateUsage] = field(default_factory=list)
+    certificate_id: str | None = None
+    public_key_id: str | None = None
     valid_from: str | None = None
     valid_to: str | None = None
 
@@ -418,6 +420,10 @@ class PublicKeyCertificate:
         return PublicKeyCertificate(
             certificate=str(data.get("certificate", "")),
             usage=[PublicKeyCertificateUsage(str(item)) for item in usage_values],
+            certificate_id=(
+                str(data["certificateId"]) if data.get("certificateId") is not None else None
+            ),
+            public_key_id=str(data["publicKeyId"]) if data.get("publicKeyId") is not None else None,
             valid_from=str(data["validFrom"]) if data.get("validFrom") is not None else None,
             valid_to=str(data["validTo"]) if data.get("validTo") is not None else None,
         )
@@ -427,6 +433,10 @@ class PublicKeyCertificate:
             "certificate": self.certificate,
             "usage": [item.value for item in self.usage],
         }
+        if not omit_none or self.certificate_id is not None:
+            payload["certificateId"] = self.certificate_id
+        if not omit_none or self.public_key_id is not None:
+            payload["publicKeyId"] = self.public_key_id
         if not omit_none or self.valid_from is not None:
             payload["validFrom"] = self.valid_from
         if not omit_none or self.valid_to is not None:

--- a/src/ksef_client/models.pyi
+++ b/src/ksef_client/models.pyi
@@ -438,6 +438,8 @@ class LighthouseStatusResponse:
 class PublicKeyCertificate:
     certificate: str
     usage: list[PublicKeyCertificateUsage] = ...
+    certificate_id: str | None = None
+    public_key_id: str | None = None
     valid_from: str | None = None
     valid_to: str | None = None
     @staticmethod

--- a/src/ksef_client/openapi_models.py
+++ b/src/ksef_client/openapi_models.py
@@ -954,6 +954,7 @@ class EffectiveSubjectLimits(OpenApiModel):
 class EncryptionInfo(OpenApiModel):
     encrypted_symmetric_key: str = field(metadata={"json_key": "encryptedSymmetricKey"})
     initialization_vector: str = field(metadata={"json_key": "initializationVector"})
+    public_key_id: Optional[str] = field(default=None, metadata={"json_key": "publicKeyId"})
 
 @dataclass(frozen=True)
 class EnrollCertificateRequest(OpenApiModel):
@@ -1238,6 +1239,7 @@ class InitTokenAuthenticationRequest(OpenApiModel):
     context_identifier: AuthenticationContextIdentifier = field(metadata={"json_key": "contextIdentifier"})
     encrypted_token: str = field(metadata={"json_key": "encryptedToken"})
     authorization_policy: Optional[AuthorizationPolicy] = field(default=None, metadata={"json_key": "authorizationPolicy"})
+    public_key_id: Optional[str] = field(default=None, metadata={"json_key": "publicKeyId"})
 
 @dataclass(frozen=True)
 class InvoiceExportRequest(OpenApiModel):
@@ -1606,6 +1608,8 @@ class PersonalPermissionsTargetIdentifier(OpenApiModel):
 @dataclass(frozen=True)
 class PublicKeyCertificate(OpenApiModel):
     certificate: str
+    certificate_id: str = field(metadata={"json_key": "certificateId"})
+    public_key_id: str = field(metadata={"json_key": "publicKeyId"})
     usage: list[PublicKeyCertificateUsage]
     valid_from: str = field(metadata={"json_key": "validFrom"})
     valid_to: str = field(metadata={"json_key": "validTo"})

--- a/src/ksef_client/services/auth.py
+++ b/src/ksef_client/services/auth.py
@@ -43,6 +43,7 @@ def build_ksef_token_auth_request(
     context_identifier_type: str,
     context_identifier_value: str,
     encrypted_token_base64: str,
+    public_key_id: str | None = None,
     authorization_policy: AuthorizationPolicy | None = None,
 ) -> InitTokenAuthenticationRequest:
     return InitTokenAuthenticationRequest(
@@ -52,6 +53,7 @@ def build_ksef_token_auth_request(
             value=context_identifier_value,
         ),
         encrypted_token=encrypted_token_base64,
+        public_key_id=public_key_id,
         authorization_policy=authorization_policy,
     )
 

--- a/src/ksef_client/services/auth.py
+++ b/src/ksef_client/services/auth.py
@@ -10,7 +10,21 @@ from ..models import (
 )
 from .crypto import encrypt_ksef_token_ec, encrypt_ksef_token_rsa
 
-AUTH_NS = "http://ksef.mf.gov.pl/auth/token/2.0"
+AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION = {
+    "2.0": "http://ksef.mf.gov.pl/auth/token/2.0",
+    "2.1": "http://ksef.mf.gov.pl/auth/token/2.1",
+}
+DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION = "2.1"
+AUTH_NS = AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION[
+    DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION
+]
+
+
+def _auth_token_request_namespace(schema_version: str) -> str:
+    try:
+        return AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION[schema_version]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported AuthTokenRequest schema version: {schema_version}") from exc
 
 
 def build_auth_token_request_xml(
@@ -20,12 +34,14 @@ def build_auth_token_request_xml(
     context_identifier_value: str,
     subject_identifier_type: str = "certificateSubject",
     authorization_policy_xml: str | None = None,
+    schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
 ) -> str:
     context_tag = _context_tag(context_identifier_type)
+    namespace = _auth_token_request_namespace(schema_version)
     auth_policy = f"\n  {authorization_policy_xml}" if authorization_policy_xml else ""
     xml = (
         '<?xml version="1.0" encoding="utf-8"?>\n'
-        f'<AuthTokenRequest xmlns="{AUTH_NS}">\n'
+        f'<AuthTokenRequest xmlns="{namespace}">\n'
         f"  <Challenge>{challenge}</Challenge>\n"
         "  <ContextIdentifier>\n"
         f"    <{context_tag}>{context_identifier_value}</{context_tag}>\n"

--- a/src/ksef_client/services/crypto.py
+++ b/src/ksef_client/services/crypto.py
@@ -114,13 +114,18 @@ def get_stream_metadata(stream: BinaryIO) -> FileMetadata:
     )
 
 
-def build_encryption_data(public_certificate: str | bytes) -> EncryptionData:
+def build_encryption_data(
+    public_certificate: str | bytes,
+    *,
+    public_key_id: str | None = None,
+) -> EncryptionData:
     key = generate_symmetric_key()
     iv = generate_iv()
     encrypted_key = encrypt_rsa_oaep(public_certificate, key)
     encryption_info = EncryptionInfo(
         encrypted_symmetric_key=base64.b64encode(encrypted_key).decode("ascii"),
         initialization_vector=base64.b64encode(iv).decode("ascii"),
+        public_key_id=public_key_id,
     )
     return EncryptionData(key=key, iv=iv, encryption_info=encryption_info)
 

--- a/src/ksef_client/services/workflows.py
+++ b/src/ksef_client/services/workflows.py
@@ -360,6 +360,7 @@ class AuthCoordinator:
         *,
         token: str,
         public_certificate: str,
+        public_key_id: str | None = None,
         context_identifier_type: str,
         context_identifier_value: str,
         method: str = "rsa",
@@ -382,6 +383,7 @@ class AuthCoordinator:
                 context_identifier_type=context_identifier_type,
                 context_identifier_value=context_identifier_value,
                 encrypted_token_base64=encrypted_token_b64,
+                public_key_id=public_key_id,
                 authorization_policy=authorization_policy,
             )
         )
@@ -497,6 +499,7 @@ class AsyncAuthCoordinator:
         *,
         token: str,
         public_certificate: str,
+        public_key_id: str | None = None,
         context_identifier_type: str,
         context_identifier_value: str,
         method: str = "rsa",
@@ -519,6 +522,7 @@ class AsyncAuthCoordinator:
                 context_identifier_type=context_identifier_type,
                 context_identifier_value=context_identifier_value,
                 encrypted_token_base64=encrypted_token_b64,
+                public_key_id=public_key_id,
                 authorization_policy=authorization_policy,
             )
         )
@@ -569,10 +573,11 @@ class OnlineSessionWorkflow:
         *,
         form_code: FormCode,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         upo_v43: bool = False,
     ) -> OnlineSessionHandle:
-        encryption = build_encryption_data(public_certificate)
+        encryption = build_encryption_data(public_certificate, public_key_id=public_key_id)
         response = self._sessions.open_online_session(
             OpenOnlineSessionRequest(
                 form_code=form_code,
@@ -639,10 +644,11 @@ class AsyncOnlineSessionWorkflow:
         *,
         form_code: FormCode,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         upo_v43: bool = False,
     ) -> AsyncOnlineSessionHandle:
-        encryption = build_encryption_data(public_certificate)
+        encryption = build_encryption_data(public_certificate, public_key_id=public_key_id)
         response = await self._sessions.open_online_session(
             OpenOnlineSessionRequest(
                 form_code=form_code,
@@ -711,11 +717,12 @@ class BatchSessionWorkflow:
         form_code: FormCode,
         zip_bytes: bytes,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         offline_mode: bool | None = None,
         upo_v43: bool = False,
     ) -> BatchSessionHandle:
-        encryption = build_encryption_data(public_certificate)
+        encryption = build_encryption_data(public_certificate, public_key_id=public_key_id)
         encrypted_parts, batch_file_info = encrypt_batch_parts(
             zip_bytes, encryption.key, encryption.iv
         )
@@ -764,6 +771,7 @@ class BatchSessionWorkflow:
         form_code: FormCode,
         zip_bytes: bytes,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         offline_mode: bool | None = None,
         upo_v43: bool = False,
@@ -773,6 +781,7 @@ class BatchSessionWorkflow:
             form_code=form_code,
             zip_bytes=zip_bytes,
             public_certificate=public_certificate,
+            public_key_id=public_key_id,
             access_token=access_token,
             offline_mode=offline_mode,
             upo_v43=upo_v43,
@@ -795,11 +804,12 @@ class AsyncBatchSessionWorkflow:
         form_code: FormCode,
         zip_bytes: bytes,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         offline_mode: bool | None = None,
         upo_v43: bool = False,
     ) -> AsyncBatchSessionHandle:
-        encryption = build_encryption_data(public_certificate)
+        encryption = build_encryption_data(public_certificate, public_key_id=public_key_id)
         encrypted_parts, batch_file_info = encrypt_batch_parts(
             zip_bytes, encryption.key, encryption.iv
         )
@@ -848,6 +858,7 @@ class AsyncBatchSessionWorkflow:
         form_code: FormCode,
         zip_bytes: bytes,
         public_certificate: str,
+        public_key_id: str | None = None,
         access_token: str,
         offline_mode: bool | None = None,
         upo_v43: bool = False,
@@ -858,6 +869,7 @@ class AsyncBatchSessionWorkflow:
             form_code=form_code,
             zip_bytes=zip_bytes,
             public_certificate=public_certificate,
+            public_key_id=public_key_id,
             access_token=access_token,
             offline_mode=offline_mode,
             upo_v43=upo_v43,

--- a/src/ksef_client/services/workflows.py
+++ b/src/ksef_client/services/workflows.py
@@ -31,7 +31,12 @@ from ..models import (
     SendInvoiceResponse,
 )
 from ..utils.zip_utils import unzip_bytes_safe
-from .auth import build_auth_token_request_xml, build_ksef_token_auth_request, encrypt_ksef_token
+from .auth import (
+    DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
+    build_auth_token_request_xml,
+    build_ksef_token_auth_request,
+    encrypt_ksef_token,
+)
 from .batch import encrypt_batch_parts
 from .crypto import (
     EncryptionData,
@@ -297,6 +302,7 @@ class AuthCoordinator:
         verify_certificate_chain: bool | None = None,
         enforce_xades_compliance: bool = False,
         authorization_policy_xml: str | None = None,
+        auth_request_schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
         poll_interval_seconds: float = 2.0,
         max_attempts: int = 30,
     ) -> AuthResult:
@@ -309,6 +315,7 @@ class AuthCoordinator:
             verify_certificate_chain=verify_certificate_chain,
             enforce_xades_compliance=enforce_xades_compliance,
             authorization_policy_xml=authorization_policy_xml,
+            auth_request_schema_version=auth_request_schema_version,
             poll_interval_seconds=poll_interval_seconds,
             max_attempts=max_attempts,
         )
@@ -324,6 +331,7 @@ class AuthCoordinator:
         verify_certificate_chain: bool | None = None,
         enforce_xades_compliance: bool = False,
         authorization_policy_xml: str | None = None,
+        auth_request_schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
         poll_interval_seconds: float = 2.0,
         max_attempts: int = 30,
     ) -> AuthResult:
@@ -334,6 +342,7 @@ class AuthCoordinator:
             context_identifier_value=context_identifier_value,
             subject_identifier_type=subject_identifier_type,
             authorization_policy_xml=authorization_policy_xml,
+            schema_version=auth_request_schema_version,
         )
         from .xades import sign_xades_enveloped
 
@@ -436,6 +445,7 @@ class AsyncAuthCoordinator:
         verify_certificate_chain: bool | None = None,
         enforce_xades_compliance: bool = False,
         authorization_policy_xml: str | None = None,
+        auth_request_schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
         poll_interval_seconds: float = 2.0,
         max_attempts: int = 30,
     ) -> AuthResult:
@@ -448,6 +458,7 @@ class AsyncAuthCoordinator:
             verify_certificate_chain=verify_certificate_chain,
             enforce_xades_compliance=enforce_xades_compliance,
             authorization_policy_xml=authorization_policy_xml,
+            auth_request_schema_version=auth_request_schema_version,
             poll_interval_seconds=poll_interval_seconds,
             max_attempts=max_attempts,
         )
@@ -463,6 +474,7 @@ class AsyncAuthCoordinator:
         verify_certificate_chain: bool | None = None,
         enforce_xades_compliance: bool = False,
         authorization_policy_xml: str | None = None,
+        auth_request_schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION,
         poll_interval_seconds: float = 2.0,
         max_attempts: int = 30,
     ) -> AuthResult:
@@ -473,6 +485,7 @@ class AsyncAuthCoordinator:
             context_identifier_value=context_identifier_value,
             subject_identifier_type=subject_identifier_type,
             authorization_policy_xml=authorization_policy_xml,
+            schema_version=auth_request_schema_version,
         )
         from .xades import sign_xades_enveloped
 

--- a/tests/cli/integration/test_send_batch.py
+++ b/tests/cli/integration/test_send_batch.py
@@ -50,12 +50,12 @@ def test_send_batch_success(runner, monkeypatch, tmp_path) -> None:
     assert seen["save_upo_overwrite"] is False
 
 
-def test_send_batch_rr_form_code_override(runner, monkeypatch, tmp_path) -> None:
+def test_send_batch_fa_rr_form_code(runner, monkeypatch, tmp_path) -> None:
     seen: dict[str, object] = {}
 
     def _fake_send(**kwargs):
         seen.update(kwargs)
-        return {"session_ref": "BATCH-RR"}
+        return {"session_ref": "BATCH-FA-RR"}
 
     monkeypatch.setattr(send_cmd, "send_batch_invoices", _fake_send)
     batch_dir = tmp_path / "batch"
@@ -73,14 +73,14 @@ def test_send_batch_rr_form_code_override(runner, monkeypatch, tmp_path) -> None
             "--schema-version",
             "1-1E",
             "--form-value",
-            "RR",
+            "FA_RR",
         ],
     )
 
     assert result.exit_code == 0
     assert seen["system_code"] == "FA_RR (1)"
     assert seen["schema_version"] == "1-1E"
-    assert seen["form_value"] == "RR"
+    assert seen["form_value"] == "FA_RR"
 
 
 def test_send_batch_save_upo_overwrite_flag(runner, monkeypatch, tmp_path) -> None:

--- a/tests/cli/integration/test_send_online.py
+++ b/tests/cli/integration/test_send_online.py
@@ -54,17 +54,17 @@ def test_send_online_success(runner, monkeypatch, tmp_path) -> None:
     assert seen["save_upo_overwrite"] is False
 
 
-def test_send_online_rr_form_code_override(runner, monkeypatch, tmp_path) -> None:
+def test_send_online_fa_rr_form_code(runner, monkeypatch, tmp_path) -> None:
     seen: dict[str, object] = {}
 
     def _fake_send(**kwargs):
         seen.update(kwargs)
-        return {"session_ref": "SES-RR", "invoice_ref": "INV-RR"}
+        return {"session_ref": "SES-FA-RR", "invoice_ref": "INV-FA-RR"}
 
     monkeypatch.setattr(send_cmd, "send_online_invoice", _fake_send)
 
-    invoice_path = tmp_path / "rr.xml"
-    invoice_path.write_text("<rr/>", encoding="utf-8")
+    invoice_path = tmp_path / "fa-rr.xml"
+    invoice_path.write_text("<fa-rr/>", encoding="utf-8")
 
     result = runner.invoke(
         app,
@@ -78,14 +78,14 @@ def test_send_online_rr_form_code_override(runner, monkeypatch, tmp_path) -> Non
             "--schema-version",
             "1-1E",
             "--form-value",
-            "RR",
+            "FA_RR",
         ],
     )
 
     assert result.exit_code == 0
     assert seen["system_code"] == "FA_RR (1)"
     assert seen["schema_version"] == "1-1E"
-    assert seen["form_value"] == "RR"
+    assert seen["form_value"] == "FA_RR"
 
 
 def test_send_online_save_upo_overwrite_flag(runner, monkeypatch, tmp_path) -> None:

--- a/tests/cli/unit/test_auth_manager.py
+++ b/tests/cli/unit/test_auth_manager.py
@@ -17,7 +17,11 @@ class _FakeClient:
     def __init__(self) -> None:
         self.security = SimpleNamespace(
             get_public_key_certificates=lambda: [
-                {"usage": ["KsefTokenEncryption"], "certificate": "CERT"},
+                {
+                    "usage": ["KsefTokenEncryption"],
+                    "certificate": "CERT",
+                    "publicKeyId": "key-id",
+                },
             ]
         )
         self.auth = SimpleNamespace(
@@ -49,11 +53,13 @@ class _FakeAuthResult:
 
 
 class _FakeAuthCoordinator:
+    last_ksef_token_kwargs: dict[str, object] = {}
+
     def __init__(self, _auth) -> None:
         _ = _auth
 
     def authenticate_with_ksef_token(self, **kwargs) -> _FakeAuthResult:
-        _ = kwargs
+        type(self).last_ksef_token_kwargs = dict(kwargs)
         return _FakeAuthResult(
             reference_number="ref-1",
             tokens=_FakeTokens(
@@ -271,6 +277,7 @@ def test_login_with_token_caches_ksef_reference_number(monkeypatch) -> None:
     )
 
     assert saved["ksef_token_reference_number"] == "REF-123"
+    assert _FakeAuthCoordinator.last_ksef_token_kwargs["public_key_id"] == "key-id"
 
 
 def test_login_with_token_uses_profile_context_fallback(monkeypatch) -> None:

--- a/tests/cli/unit/test_auth_manager.py
+++ b/tests/cli/unit/test_auth_manager.py
@@ -354,12 +354,26 @@ def test_status_and_logout(monkeypatch) -> None:
 def test_select_certificate_and_require_non_empty_errors() -> None:
     cert = manager._select_certificate(
         [
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-OLD",
+                "publicKeyId": "key-old",
+                "validFrom": "2026-01-01T00:00:00Z",
+                "validTo": "2999-01-01T00:00:00Z",
+            },
             {"usage": ["KsefTokenEncryption"], "certificate": ""},
-            {"usage": ["KsefTokenEncryption"], "certificate": "CERT"},
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-NEW",
+                "publicKeyId": "key-new",
+                "validFrom": "2026-02-01T00:00:00Z",
+                "validTo": "2999-01-01T00:00:00Z",
+            },
         ],
         "KsefTokenEncryption",
     )
-    assert cert == "CERT"
+    assert cert.certificate == "CERT-NEW"
+    assert cert.public_key_id == "key-new"
 
     with pytest.raises(CliError) as cert_error:
         manager._select_certificate([], "KsefTokenEncryption")
@@ -376,11 +390,40 @@ def test_select_certificate_supports_object_payloads() -> None:
             SimpleNamespace(
                 usage=[SimpleNamespace(value="KsefTokenEncryption")],
                 certificate="CERT-OBJ",
+                public_key_id="key-obj",
             )
         ],
         "KsefTokenEncryption",
     )
-    assert cert == "CERT-OBJ"
+    assert cert.certificate == "CERT-OBJ"
+    assert cert.public_key_id == "key-obj"
+
+
+def test_select_certificate_ignores_invalid_and_future_validity() -> None:
+    cert = manager._select_certificate(
+        [
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-FUTURE",
+                "validFrom": "2999-01-01T00:00:00Z",
+            },
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-INVALID",
+                "publicKeyId": "key-invalid",
+                "validFrom": "not-a-date",
+            },
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-NAIVE",
+                "validFrom": "2026-01-01T00:00:00",
+            },
+        ],
+        "KsefTokenEncryption",
+    )
+
+    assert cert.certificate == "CERT-NAIVE"
+    assert cert.public_key_id is None
 
 
 def test_resolve_base_url_prefers_provided_value() -> None:

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -330,6 +330,34 @@ def test_list_invoices_rejects_invalid_date_type(monkeypatch) -> None:
     assert exc.value.code == ExitCode.VALIDATION_ERROR
 
 
+def test_select_certificate_uses_current_newest_valid_from() -> None:
+    cert = adapters._select_certificate(
+        [
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-FUTURE",
+                "validFrom": "2999-01-01T00:00:00Z",
+            },
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-INVALID",
+                "publicKeyId": "key-invalid",
+                "validFrom": "not-a-date",
+            },
+            {
+                "usage": ["KsefTokenEncryption"],
+                "certificate": "CERT-NAIVE",
+                "publicKeyId": "key-naive",
+                "validFrom": "2026-01-01T00:00:00",
+            },
+        ],
+        "KsefTokenEncryption",
+    )
+
+    assert cert.certificate == "CERT-NAIVE"
+    assert cert.public_key_id == "key-naive"
+
+
 def test_get_lighthouse_status_success(monkeypatch) -> None:
     seen: dict[str, object] = {}
 

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -750,7 +750,13 @@ def test_wait_for_upo_rejects_invalid_polling_options(monkeypatch) -> None:
 def test_send_online_invoice_success_with_wait_and_upo(monkeypatch, tmp_path) -> None:
     class _Security:
         def get_public_key_certificates(self):
-            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+            return [
+                {
+                    "usage": ["SymmetricKeyEncryption"],
+                    "certificate": "CERT",
+                    "publicKeyId": "key-id",
+                }
+            ]
 
     class _Sessions:
         def get_session_invoice_status(self, session_ref, invoice_ref, access_token):
@@ -766,8 +772,16 @@ def test_send_online_invoice_success_with_wait_and_upo(monkeypatch, tmp_path) ->
             _ = sessions
             self.closed_refs: list[str] = []
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-ONLINE-1",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -829,7 +843,13 @@ def test_send_online_invoice_save_upo_without_extension_is_treated_as_file(
 ) -> None:
     class _Security:
         def get_public_key_certificates(self):
-            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+            return [
+                {
+                    "usage": ["SymmetricKeyEncryption"],
+                    "certificate": "CERT",
+                    "publicKeyId": "key-id",
+                }
+            ]
 
     class _Sessions:
         def get_session_invoice_status(self, session_ref, invoice_ref, access_token):
@@ -844,8 +864,16 @@ def test_send_online_invoice_save_upo_without_extension_is_treated_as_file(
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-ONLINE-2",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -893,14 +921,28 @@ def test_send_online_invoice_save_upo_without_extension_is_treated_as_file(
 def test_send_online_invoice_save_upo_overwrite_support(monkeypatch, tmp_path) -> None:
     class _Security:
         def get_public_key_certificates(self):
-            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+            return [
+                {
+                    "usage": ["SymmetricKeyEncryption"],
+                    "certificate": "CERT",
+                    "publicKeyId": "key-id",
+                }
+            ]
 
     class _OnlineWorkflow:
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-ONLINE-OVERWRITE",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -2155,8 +2197,16 @@ def test_send_online_invoice_missing_reference_and_failed_close(monkeypatch, tmp
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-ONLINE-X",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -2357,8 +2407,16 @@ def test_send_online_invoice_sets_empty_ksef_and_upo_path_without_save(
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-NO-KSEF",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -2500,7 +2558,13 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
 
     class _Security:
         def get_public_key_certificates(self):
-            return [{"usage": ["SymmetricKeyEncryption"], "certificate": "CERT"}]
+            return [
+                {
+                    "usage": ["SymmetricKeyEncryption"],
+                    "certificate": "CERT",
+                    "publicKeyId": "key-id",
+                }
+            ]
 
     class _Invoices:
         def export_invoices(self, payload, access_token):
@@ -2537,8 +2601,14 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
         encryption_info=SimpleNamespace(
             encrypted_symmetric_key="enc",
             initialization_vector="iv",
+            public_key_id="key-id",
         ),
     )
+
+    def _build_encryption_data(cert, **kwargs):
+        seen["encryption_cert"] = cert
+        seen["public_key_id"] = kwargs.get("public_key_id")
+        return fake_encryption
 
     monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
     monkeypatch.setattr(
@@ -2548,7 +2618,7 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
             invoices=_Invoices(), security=_Security(), http_client=SimpleNamespace()
         ),
     )
-    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "build_encryption_data", _build_encryption_data)
     monkeypatch.setattr(adapters, "ExportWorkflow", _FakeExportWorkflow)
     monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
 
@@ -2570,6 +2640,9 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.only_metadata is False
+    assert payload.encryption.public_key_id == "key-id"
+    assert seen["encryption_cert"] == "CERT"
+    assert seen["public_key_id"] == "key-id"
     assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.ISSUE
     assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is False
     assert (tmp_path / "_metadata.json").exists()
@@ -2641,7 +2714,7 @@ def test_run_export_only_metadata_success(monkeypatch, tmp_path) -> None:
             invoices=_Invoices(), security=_Security(), http_client=SimpleNamespace()
         ),
     )
-    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert, **kwargs: fake_encryption)
     monkeypatch.setattr(adapters, "ExportWorkflow", _FakeExportWorkflow)
     monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
 
@@ -2718,7 +2791,7 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
             invoices=_Invoices(), security=_Security(), http_client=SimpleNamespace()
         ),
     )
-    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert, **kwargs: fake_encryption)
     monkeypatch.setattr(adapters, "ExportWorkflow", _FakeExportWorkflow)
     monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
 
@@ -2812,7 +2885,7 @@ def test_run_export_missing_reference_and_package(monkeypatch, tmp_path) -> None
     )
 
     monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
-    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert, **kwargs: fake_encryption)
     monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
 
     monkeypatch.setattr(
@@ -2866,7 +2939,7 @@ def test_run_export_requires_encryption_metadata(monkeypatch, tmp_path) -> None:
     fake_encryption = adapters.EncryptionData(key=b"k" * 32, iv=b"i" * 16, encryption_info=None)
 
     monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
-    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert: fake_encryption)
+    monkeypatch.setattr(adapters, "build_encryption_data", lambda cert, **kwargs: fake_encryption)
     monkeypatch.setattr(
         adapters,
         "create_client",
@@ -3208,8 +3281,16 @@ def test_send_online_invoice_success_without_waits(monkeypatch, tmp_path) -> Non
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-NO-WAIT",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),
@@ -3262,8 +3343,16 @@ def test_send_online_invoice_wait_status_without_wait_upo(monkeypatch, tmp_path)
         def __init__(self, sessions):
             _ = sessions
 
-        def open_session(self, *, form_code, public_certificate, access_token, upo_v43=False):
-            _ = (form_code, public_certificate, access_token, upo_v43)
+        def open_session(
+            self,
+            *,
+            form_code,
+            public_certificate,
+            access_token,
+            upo_v43=False,
+            public_key_id=None,
+        ):
+            _ = (form_code, public_certificate, access_token, upo_v43, public_key_id)
             return SimpleNamespace(
                 session_reference_number="SES-STATUS-ONLY",
                 encryption_data=SimpleNamespace(key=b"k", iv=b"i"),

--- a/tests/cli/unit/test_session_ops.py
+++ b/tests/cli/unit/test_session_ops.py
@@ -222,7 +222,14 @@ def test_open_online_session_closes_handle_when_save_fails(monkeypatch) -> None:
 
     monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
     monkeypatch.setattr(session_ops.adapters, "_build_form_code", lambda *args: _form_code())
-    monkeypatch.setattr(session_ops.adapters, "_select_certificate", lambda certs, usage: "CERT")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_select_certificate",
+        lambda certs, usage: session_ops.adapters.SelectedPublicKeyCertificate(
+            "CERT",
+            "key-id",
+        ),
+    )
     monkeypatch.setattr(session_ops, "OnlineSessionWorkflow", _Workflow)
     monkeypatch.setattr(
         session_ops.adapters,
@@ -491,7 +498,14 @@ def test_open_batch_session_closes_handle_when_save_fails(monkeypatch) -> None:
 
     monkeypatch.setattr(session_ops.adapters, "_require_access_token", lambda profile: "token")
     monkeypatch.setattr(session_ops.adapters, "_build_form_code", lambda *args: _form_code())
-    monkeypatch.setattr(session_ops.adapters, "_select_certificate", lambda certs, usage: "CERT")
+    monkeypatch.setattr(
+        session_ops.adapters,
+        "_select_certificate",
+        lambda certs, usage: session_ops.adapters.SelectedPublicKeyCertificate(
+            "CERT",
+            "key-id",
+        ),
+    )
     monkeypatch.setattr(
         session_ops,
         "_build_batch_payload_source",

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -31,6 +31,7 @@ from ksef_client.clients.security import (
     AsyncSecurityClient,
     SecurityClient,
     _normalize_certificate_usage,
+    _select_public_key_certificate,
 )
 from ksef_client.clients.sessions import AsyncSessionsClient, SessionsClient
 from ksef_client.clients.testdata import AsyncTestDataClient, TestDataClient
@@ -495,10 +496,20 @@ class ClientsTests(unittest.TestCase):
         security_certificates = [
             m.PublicKeyCertificate.from_dict(
                 {
-                    "certificate": "pem-1",
+                    "certificate": "pem-old",
+                    "publicKeyId": "key-old",
                     "usage": ["KsefTokenEncryption"],
                     "validFrom": "2026-01-01T00:00:00Z",
-                    "validTo": "2026-12-31T23:59:59Z",
+                    "validTo": "2999-12-31T23:59:59Z",
+                }
+            ),
+            m.PublicKeyCertificate.from_dict(
+                {
+                    "certificate": "pem-new",
+                    "publicKeyId": "key-new",
+                    "usage": ["KsefTokenEncryption"],
+                    "validFrom": "2026-02-01T00:00:00Z",
+                    "validTo": "2999-12-31T23:59:59Z",
                 }
             )
         ]
@@ -508,11 +519,12 @@ class ClientsTests(unittest.TestCase):
             selected = security.get_public_key_certificate(
                 m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION
             )
-            self.assertEqual(selected.certificate, "pem-1")
+            self.assertEqual(selected.certificate, "pem-new")
+            self.assertEqual(selected.public_key_id, "key-new")
             selected_pem = security.get_public_key_certificate_pem("KsefTokenEncryption")
-            self.assertEqual(selected_pem, "pem-1")
+            self.assertEqual(selected_pem, "pem-new")
             selected_from_str = security.get_public_key_certificate("KsefTokenEncryption")
-            self.assertEqual(selected_from_str.certificate, "pem-1")
+            self.assertEqual(selected_from_str.certificate, "pem-new")
             self.assertEqual(
                 _normalize_certificate_usage("ksef_token_encryption"),
                 m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION,
@@ -521,6 +533,28 @@ class ClientsTests(unittest.TestCase):
                 security.get_public_key_certificate("SymmetricKeyEncryption")
             with self.assertRaises(ValueError):
                 _normalize_certificate_usage("bad-usage")
+
+        selected_edge = _select_public_key_certificate(
+            [
+                m.PublicKeyCertificate(
+                    certificate="future",
+                    usage=[m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION],
+                    valid_from="2999-01-01T00:00:00Z",
+                ),
+                m.PublicKeyCertificate(
+                    certificate="invalid-date",
+                    usage=[m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION],
+                    valid_from="not-a-date",
+                ),
+                m.PublicKeyCertificate(
+                    certificate="naive",
+                    usage=[m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION],
+                    valid_from="2026-01-01T00:00:00",
+                ),
+            ],
+            m.PublicKeyCertificateUsage.KSEFTOKENENCRYPTION,
+        )
+        self.assertEqual(selected_edge.certificate, "naive")
 
         testdata = TestDataClient(self.http)
         with (
@@ -883,10 +917,20 @@ class AsyncClientsTests(unittest.IsolatedAsyncioTestCase):
         security_certificates = [
             m.PublicKeyCertificate.from_dict(
                 {
-                    "certificate": "pem-1",
+                    "certificate": "pem-old",
+                    "publicKeyId": "key-old",
                     "usage": ["SymmetricKeyEncryption"],
                     "validFrom": "2026-01-01T00:00:00Z",
-                    "validTo": "2026-12-31T23:59:59Z",
+                    "validTo": "2999-12-31T23:59:59Z",
+                }
+            ),
+            m.PublicKeyCertificate.from_dict(
+                {
+                    "certificate": "pem-new",
+                    "publicKeyId": "key-new",
+                    "usage": ["SymmetricKeyEncryption"],
+                    "validFrom": "2026-02-01T00:00:00Z",
+                    "validTo": "2999-12-31T23:59:59Z",
                 }
             )
         ]
@@ -896,15 +940,16 @@ class AsyncClientsTests(unittest.IsolatedAsyncioTestCase):
             selected = await security.get_public_key_certificate(
                 m.PublicKeyCertificateUsage.SYMMETRICKEYENCRYPTION
             )
-            self.assertEqual(selected.certificate, "pem-1")
+            self.assertEqual(selected.certificate, "pem-new")
+            self.assertEqual(selected.public_key_id, "key-new")
             selected_pem = await security.get_public_key_certificate_pem(
                 "SymmetricKeyEncryption"
             )
-            self.assertEqual(selected_pem, "pem-1")
+            self.assertEqual(selected_pem, "pem-new")
             selected_from_str = await security.get_public_key_certificate(
                 "SymmetricKeyEncryption"
             )
-            self.assertEqual(selected_from_str.certificate, "pem-1")
+            self.assertEqual(selected_from_str.certificate, "pem-new")
             self.assertEqual(
                 _normalize_certificate_usage("symmetric-key-encryption"),
                 m.PublicKeyCertificateUsage.SYMMETRICKEYENCRYPTION,

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -134,13 +134,18 @@ class CryptoTests(unittest.TestCase):
 
     def test_build_encryption_data(self):
         rsa_cert = generate_rsa_cert()
-        encryption = crypto.build_encryption_data(rsa_cert.certificate_pem)
+        encryption = crypto.build_encryption_data(
+            rsa_cert.certificate_pem,
+            public_key_id="key-id",
+        )
         self.assertEqual(len(encryption.key), 32)
         self.assertEqual(len(encryption.iv), 16)
         encryption_info = encryption.encryption_info
         self.assertIsNotNone(encryption_info)
         assert encryption_info is not None
         self.assertTrue(encryption_info.encrypted_symmetric_key)
+        self.assertEqual(encryption_info.public_key_id, "key-id")
+        self.assertEqual(encryption_info.to_dict()["publicKeyId"], "key-id")
 
     def test_encrypt_rsa_oaep(self):
         rsa_cert = generate_rsa_cert()

--- a/tests/test_e2e_token_flows.py
+++ b/tests/test_e2e_token_flows.py
@@ -20,6 +20,7 @@ from ksef_client import KsefClient, KsefClientOptions, KsefEnvironment
 from ksef_client import models as m
 from ksef_client.exceptions import KsefHttpError, KsefRateLimitError
 from ksef_client.services import AuthCoordinator, OnlineSessionWorkflow
+from ksef_client.services.auth import DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION
 
 pytestmark = pytest.mark.e2e
 
@@ -42,6 +43,7 @@ class E2EConfig:
     certificate_pem: str | None = None
     private_key_pem: str | None = None
     subject_identifier_type: str | None = None
+    auth_request_schema_version: str = DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION
 
 
 def _optional_any(*names: str) -> str | None:
@@ -372,6 +374,10 @@ def _load_test_xades_config() -> E2EConfig:
         subject_identifier_type=(
             _optional_any("KSEF_TEST_XADES_SUBJECT_IDENTIFIER_TYPE") or "certificateSubject"
         ),
+        auth_request_schema_version=(
+            _optional_any("KSEF_TEST_XADES_AUTH_REQUEST_SCHEMA_VERSION")
+            or DEFAULT_AUTH_TOKEN_REQUEST_SCHEMA_VERSION
+        ),
     )
 
 
@@ -402,6 +408,9 @@ def _load_demo_xades_config() -> E2EConfig:
         ),
         subject_identifier_type=(
             _optional_any("KSEF_DEMO_XADES_SUBJECT_IDENTIFIER_TYPE") or "certificateSubject"
+        ),
+        auth_request_schema_version=(
+            _optional_any("KSEF_DEMO_XADES_AUTH_REQUEST_SCHEMA_VERSION") or "2.0"
         ),
     )
 
@@ -610,6 +619,7 @@ def _authenticate_access_token(
             subject_identifier_type=config.subject_identifier_type or "certificateSubject",
             certificate_pem=config.certificate_pem,
             private_key_pem=config.private_key_pem,
+            auth_request_schema_version=config.auth_request_schema_version,
             max_attempts=max_attempts,
             poll_interval_seconds=poll_interval_seconds,
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -276,13 +276,19 @@ class ModelsTests(unittest.TestCase):
         cert = models.PublicKeyCertificate.from_dict(
             {
                 "certificate": "pem",
+                "certificateId": "cert-id",
+                "publicKeyId": "key-id",
                 "usage": ["KsefTokenEncryption"],
                 "validFrom": "2026-01-01T00:00:00Z",
                 "validTo": "2026-12-31T23:59:59Z",
             }
         )
+        self.assertEqual(cert.certificate_id, "cert-id")
+        self.assertEqual(cert.public_key_id, "key-id")
         self.assertEqual(cert.valid_from, "2026-01-01T00:00:00Z")
         self.assertEqual(cert.valid_to, "2026-12-31T23:59:59Z")
+        self.assertEqual(cert.to_dict()["certificateId"], "cert-id")
+        self.assertEqual(cert.to_dict()["publicKeyId"], "key-id")
         self.assertEqual(cert.to_dict()["validFrom"], "2026-01-01T00:00:00Z")
         self.assertEqual(cert.to_dict()["validTo"], "2026-12-31T23:59:59Z")
 

--- a/tests/test_openapi_models.py
+++ b/tests/test_openapi_models.py
@@ -33,11 +33,15 @@ class OpenApiModelsTests(unittest.TestCase):
     def test_unknown_enum_value_roundtrips_without_error(self):
         payload = {
             "certificate": "pem-1",
+            "certificateId": "cert-id",
+            "publicKeyId": "key-id",
             "usage": ["FutureUsage"],
             "validFrom": "2026-01-01T00:00:00Z",
             "validTo": "2026-12-31T23:59:59Z",
         }
         parsed = m.PublicKeyCertificate.from_dict(payload)
+        self.assertEqual(parsed.certificate_id, "cert-id")
+        self.assertEqual(parsed.public_key_id, "key-id")
         self.assertEqual(parsed.usage[0].value, "FutureUsage")
         self.assertEqual(parsed.to_dict()["usage"], ["FutureUsage"])
         self.assertIs(m.PublicKeyCertificateUsage("FutureUsage"), parsed.usage[0])
@@ -111,6 +115,7 @@ class OpenApiModelsTests(unittest.TestCase):
             "encryption": {
                 "encryptedSymmetricKey": "enc",
                 "initializationVector": "iv",
+                "publicKeyId": "key-id",
             },
             "filters": {
                 "subjectType": "Subject1",
@@ -124,7 +129,9 @@ class OpenApiModelsTests(unittest.TestCase):
         }
         parsed = m.InvoiceExportRequest.from_dict(payload)
         self.assertTrue(parsed.only_metadata)
+        self.assertEqual(parsed.encryption.public_key_id, "key-id")
         self.assertTrue(parsed.to_dict()["onlyMetadata"])
+        self.assertEqual(parsed.to_dict()["encryption"]["publicKeyId"], "key-id")
 
     def test_token_permission_type_contains_introspection(self):
         values = {item.value for item in m.TokenPermissionType}

--- a/tests/test_services_auth.py
+++ b/tests/test_services_auth.py
@@ -38,9 +38,12 @@ class AuthServiceTests(unittest.TestCase):
             context_identifier_type="nip",
             context_identifier_value="123",
             encrypted_token_base64="enc",
+            public_key_id="key-id",
             authorization_policy=None,
         )
         self.assertEqual(payload.encrypted_token, "enc")
+        self.assertEqual(payload.public_key_id, "key-id")
+        self.assertEqual(payload.to_dict()["publicKeyId"], "key-id")
         self.assertEqual(payload.challenge, "c")
         self.assertEqual(payload.context_identifier.value, "123")
 

--- a/tests/test_services_auth.py
+++ b/tests/test_services_auth.py
@@ -3,6 +3,7 @@ import unittest
 
 from ksef_client.services.auth import (
     AUTH_NS,
+    AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION,
     _context_tag,
     build_auth_token_request_xml,
     build_ksef_token_auth_request,
@@ -21,8 +22,28 @@ class AuthServiceTests(unittest.TestCase):
             authorization_policy_xml="<Policy/>",
         )
         self.assertIn(AUTH_NS, xml)
+        self.assertIn("http://ksef.mf.gov.pl/auth/token/2.1", xml)
         self.assertIn("<Nip>123</Nip>", xml)
         self.assertIn("<Policy/>", xml)
+
+    def test_build_auth_token_request_xml_supports_schema_2_0(self):
+        xml = build_auth_token_request_xml(
+            challenge="c",
+            context_identifier_type="nip",
+            context_identifier_value="123",
+            schema_version="2.0",
+        )
+        self.assertIn(AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION["2.0"], xml)
+        self.assertNotIn(AUTH_TOKEN_REQUEST_NAMESPACE_BY_SCHEMA_VERSION["2.1"], xml)
+
+    def test_build_auth_token_request_xml_rejects_unknown_schema_version(self):
+        with self.assertRaises(ValueError):
+            build_auth_token_request_xml(
+                challenge="c",
+                context_identifier_type="nip",
+                context_identifier_value="123",
+                schema_version="1.0",
+            )
 
     def test_context_tag(self):
         self.assertEqual(_context_tag("NIP"), "Nip")

--- a/tests/test_services_workflows.py
+++ b/tests/test_services_workflows.py
@@ -480,6 +480,29 @@ class WorkflowsTests(unittest.TestCase):
                 max_attempts=1,
             )
 
+    def test_auth_coordinator_xades_schema_version_option(self):
+        auth = StubAuthClient([200])
+        coord = workflows.AuthCoordinator(auth)
+        rsa_cert = generate_rsa_cert()
+
+        def _sign(xml, certificate_pem, private_key_pem):
+            _ = (certificate_pem, private_key_pem)
+            self.assertIn("http://ksef.mf.gov.pl/auth/token/2.0", xml)
+            self.assertNotIn("http://ksef.mf.gov.pl/auth/token/2.1", xml)
+            return "signed"
+
+        with patch("ksef_client.services.xades.sign_xades_enveloped", side_effect=_sign):
+            coord.authenticate_with_xades(
+                context_identifier_type="nip",
+                context_identifier_value="123",
+                subject_identifier_type="certificateSubject",
+                certificate_pem=rsa_cert.certificate_pem,
+                private_key_pem=rsa_cert.private_key_pem,
+                auth_request_schema_version="2.0",
+                poll_interval_seconds=0,
+                max_attempts=1,
+            )
+
     def test_online_session_workflow(self):
         sessions = StubSessionsClient()
         workflow = workflows.OnlineSessionWorkflow(sessions)

--- a/tests/test_services_workflows.py
+++ b/tests/test_services_workflows.py
@@ -158,6 +158,7 @@ class RecordingAsyncHttp:
 class StubAuthClient:
     codes: list[int]
     last_enforce_xades_compliance: bool = False
+    last_ksef_token_payload: m.InitTokenAuthenticationRequest | None = None
 
     def get_challenge(self):
         return _challenge_response()
@@ -172,6 +173,7 @@ class StubAuthClient:
         return _auth_init_response()
 
     def submit_ksef_token_auth(self, payload):
+        self.last_ksef_token_payload = payload
         return _auth_init_response()
 
     def get_auth_status(self, reference_number, authentication_token):
@@ -186,6 +188,7 @@ class StubAuthClient:
 class StubAsyncAuthClient:
     codes: list[int]
     last_enforce_xades_compliance: bool = False
+    last_ksef_token_payload: m.InitTokenAuthenticationRequest | None = None
 
     async def get_challenge(self):
         return _challenge_response()
@@ -200,6 +203,7 @@ class StubAsyncAuthClient:
         return _auth_init_response()
 
     async def submit_ksef_token_auth(self, payload):
+        self.last_ksef_token_payload = payload
         return _auth_init_response()
 
     async def get_auth_status(self, reference_number, authentication_token):
@@ -420,6 +424,7 @@ class WorkflowsTests(unittest.TestCase):
             result = coord.authenticate_with_ksef_token(
                 token="token",
                 public_certificate="cert",
+                public_key_id="key-id",
                 context_identifier_type="nip",
                 context_identifier_value="123",
                 poll_interval_seconds=0,
@@ -428,6 +433,9 @@ class WorkflowsTests(unittest.TestCase):
         self.assertEqual(result.tokens.access_token.token, "acc")
         self.assertEqual(result.access_token, "acc")
         self.assertEqual(result.refresh_token, "ref")
+        self.assertIsNotNone(auth.last_ksef_token_payload)
+        assert auth.last_ksef_token_payload is not None
+        self.assertEqual(auth.last_ksef_token_payload.public_key_id, "key-id")
 
         class StubAuthClientNoneXades(StubAuthClient):
             def submit_xades_auth_request(
@@ -479,10 +487,13 @@ class WorkflowsTests(unittest.TestCase):
         result = workflow.open_session(
             form_code=_form_code(),
             public_certificate=rsa_cert.certificate_pem,
+            public_key_id="key-id",
             access_token="token",
             upo_v43=True,
         )
         self.assertEqual(result.session_reference_number, "ref")
+        open_online_calls = [call for call in sessions.calls if call[0] == "open_online"]
+        self.assertEqual(open_online_calls[0][1].encryption.public_key_id, "key-id")
         workflow.send_invoice(
             session_reference_number="ref",
             invoice_xml=b"<xml/>",
@@ -517,12 +528,15 @@ class WorkflowsTests(unittest.TestCase):
             form_code=_form_code(),
             zip_bytes=zip_bytes,
             public_certificate=rsa_cert.certificate_pem,
+            public_key_id="key-id",
             access_token="token",
             offline_mode=True,
             upo_v43=True,
             parallelism=1,
         )
         self.assertEqual(ref, "ref")
+        open_batch_calls = [call for call in sessions.calls if call[0] == "open_batch"]
+        self.assertEqual(open_batch_calls[0][1].encryption.public_key_id, "key-id")
 
     def test_batch_session_workflow_without_offline_mode_flag(self):
         sessions = StubSessionsClient()
@@ -728,12 +742,16 @@ class AsyncWorkflowsTests(unittest.IsolatedAsyncioTestCase):
             result = await coord.authenticate_with_ksef_token(
                 token="token",
                 public_certificate="cert",
+                public_key_id="async-key-id",
                 context_identifier_type="nip",
                 context_identifier_value="123",
                 poll_interval_seconds=0,
                 max_attempts=1,
             )
         self.assertEqual(result.tokens.access_token.token, "acc")
+        self.assertIsNotNone(auth.last_ksef_token_payload)
+        assert auth.last_ksef_token_payload is not None
+        self.assertEqual(auth.last_ksef_token_payload.public_key_id, "async-key-id")
 
         rsa_cert = generate_rsa_cert()
         auth_xades = StubAsyncAuthClient([200])
@@ -849,9 +867,12 @@ class AsyncWorkflowsTests(unittest.IsolatedAsyncioTestCase):
         result = await workflow.open_session(
             form_code=_form_code(),
             public_certificate=rsa_cert.certificate_pem,
+            public_key_id="online-key-id",
             access_token="token",
             upo_v43=True,
         )
+        open_online_calls = [call for call in sessions.calls if call[0] == "open_online"]
+        self.assertEqual(open_online_calls[0][1].encryption.public_key_id, "online-key-id")
         await workflow.send_invoice(
             session_reference_number="ref",
             invoice_xml=b"<xml/>",
@@ -866,11 +887,14 @@ class AsyncWorkflowsTests(unittest.IsolatedAsyncioTestCase):
             form_code=_form_code(),
             zip_bytes=zip_bytes,
             public_certificate=rsa_cert.certificate_pem,
+            public_key_id="batch-key-id",
             access_token="token",
             offline_mode=True,
             upo_v43=True,
         )
         self.assertEqual(ref, "ref")
+        open_batch_calls = [call for call in sessions.calls if call[0] == "open_batch"]
+        self.assertEqual(open_batch_calls[0][1].encryption.public_key_id, "batch-key-id")
 
     async def test_async_batch_session_workflow_without_offline_mode_flag(self):
         sessions = StubAsyncSessionsClient()


### PR DESCRIPTION
## Summary
- sync the KSeF 2.5.0 OpenAPI snapshot and generated models
- thread `publicKeyId` through encrypted auth, session, and export flows while keeping the existing `public_certificate` API compatible
- select the current valid KSeF public certificate by usage and latest `validFrom`
- default XAdES auth requests to schema `2.1` in SDK and CLI, while pinning the demo E2E job to schema `2.0` until that environment accepts the newer payload
- remove historical `RR` wording from docs/examples and keep the `FA_RR -> FA_RR` CLI compatibility mapping for `FA_RR (1) 1-1E`

## Validation
- `python tools/generate_openapi_models.py --check --input C:\Users\smekc\Smekcio\Programowanie\ksef\ksef-docs\open-api.json`
- `python tools/check_coverage.py --src src\ksef_client\clients --openapi C:\Users\smekc\Smekcio\Programowanie\ksef\ksef-docs\open-api.json`
- `python tools/check_coverage.py --src src\ksef_client\clients --no-fallback`
- `pytest --basetemp .tmp-pytest-ksef-25 --cov=ksef_client --cov-report=term-missing --cov-fail-under=100`
- `python tools/lint.py --strict`
- `python -m pytest tests\test_e2e_token_flows.py -q`

Closes #55
