### PR TITLE
docs: refresh KSeF 2.5 compatibility wording

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - "*"
+    - title: Dependencies
+      labels:
+        - dependencies
+  exclude:
+    labels:
+      - ignore-for-release

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
+  "changelog-type": "github",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "packages": {
@@ -10,4 +11,3 @@
     }
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -12,16 +12,10 @@ Projekt odwzorowuje oficjalne przepływy KSeF i zapewnia spójny model pracy w d
 
 ## 🔄 Kompatybilność
 
-Aktualna kompatybilność: **KSeF API `v2.4.0`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.4.0/api-changelog.md#wersja-240)).
+Aktualna kompatybilność: **KSeF API `v2.5.0`** ([api-changelog.md](https://github.com/CIRFMF/ksef-docs/blob/2.5.0/api-changelog.md#wersja-250)).
 
 Od tej wersji publiczne payloady requestów SDK są **typed-only**. Do metod klientów przekazuj
 obiekty `ksef_client.models.*`, a nie surowe `dict`.
-
-> [!WARNING]
-> **Breaking change:** domyślna gałąź repo zawiera już zmianę publicznego kontraktu SDK.
-> Request payloady do klientów są `typed-only`, a wiele odpowiedzi jest teraz zwracanych jako modele
-> zamiast surowych `dict`. Jeśli integracja buduje requesty jako słowniki albo czyta odpowiedzi przez
-> `response["field"]`, wymaga migracji. Szczegóły i przykłady: [`docs/migration-typed-model-api.md`](docs/migration-typed-model-api.md).
 
 ## 🧭 Spis treści
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,11 @@ Dokumentacja opisuje **publiczne API** biblioteki `ksef-client-python` (import: 
 
 Opis kontraktu API (OpenAPI) oraz dokumenty procesowe i ograniczenia systemu znajdują się w `ksef-docs/`.
 
-Kompatybilność SDK: **KSeF API `v2.4.0`**.
+Kompatybilność SDK: **KSeF API `v2.5.0`**.
 
-> [!WARNING]
-> Publiczny kontrakt SDK na domyślnej gałęzi repo używa typowanych modeli `ksef_client.models`.
-> Payloady requestów są `typed-only`, a wiele metod klientów zwraca modele odpowiedzi zamiast surowych
-> `dict`. Jeśli migrujesz starszą integrację, zobacz [`migration-typed-model-api.md`](migration-typed-model-api.md).
+Publiczny kontrakt SDK używa typowanych modeli `ksef_client.models`. Payloady requestów są
+`typed-only`, a wiele metod klientów zwraca modele odpowiedzi zamiast surowych `dict`. Jeśli
+migrujesz starszą integrację, zobacz [`migration-typed-model-api.md`](migration-typed-model-api.md).
 
 ## Wymagania
 

--- a/docs/api/tokens.md
+++ b/docs/api/tokens.md
@@ -12,7 +12,7 @@ Tworzy nowy token. Operacja jest asynchroniczna – odpowiedź zawiera numer ref
 
 Endpoint: `GET /tokens`
 
-Od KSeF API 2.4.0 endpoint zwraca też informacje o tokenie użytym do bieżącego uwierzytelnienia,
+Od KSeF API 2.5.0 endpoint zwraca też informacje o tokenie użytym do bieżącego uwierzytelnienia,
 nawet jeśli nie ma on uprawnień `CredentialsManage` / `CredentialsRead`.
 
 Parametry:
@@ -24,14 +24,14 @@ Parametry:
 
 Endpoint: `GET /tokens/{referenceNumber}`
 
-Od KSeF API 2.4.0 można pobrać status tokenu użytego do bieżącego uwierzytelnienia także bez
+Od KSeF API 2.5.0 można pobrać status tokenu użytego do bieżącego uwierzytelnienia także bez
 dodatkowych uprawnień do zarządzania tokenami.
 
 ## `revoke_token(reference_number, access_token)`
 
 Endpoint: `DELETE /tokens/{referenceNumber}` (204)
 
-Od KSeF API 2.4.0 można unieważnić token użyty do bieżącego uwierzytelnienia bez uprawnienia
+Od KSeF API 2.5.0 można unieważnić token użyty do bieżącego uwierzytelnienia bez uprawnienia
 `CredentialsManage`.
 
 W CLI odpowiada temu komenda `ksef auth revoke-self-token`, która w pierwszej kolejności używa

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,7 +32,7 @@ Specjalny przypadek dla `429 Too Many Requests`.
 
 ## Problem Details i `exc.problem`
 
-KSeF API 2.4.0 rozszerza odpowiedzi błędów o format `application/problem+json`.
+KSeF API 2.5.0 rozszerza odpowiedzi błędów o format `application/problem+json`.
 
 SDK mapuje `exc.problem` do jednego z modeli:
 


### PR DESCRIPTION
## Summary
- refresh compatibility docs from KSeF `2.4.0` to `2.5.0`
- remove obsolete `Warning` / `Breaking change` callouts from the README docs flow
- keep automated release notes more descriptive for larger KSeF upgrades

## Validation
- `git diff --check`
- `rg -n "v2\.4\.0|2\.4\.0|Breaking change|\[!WARNING\]" README.md docs .github`
