### PR TITLE
Fix export HWM guard for non-PermanentStorage date ranges

### DIFF
--- a/src/ksef_client/cli/commands/export_cmd.py
+++ b/src/ksef_client/cli/commands/export_cmd.py
@@ -80,8 +80,8 @@ def export_run(
     subject_type: str = typer.Option(
         "Subject1", "--subject-type", help="KSeF subject type filter."
     ),
-    restrict_to_permanent_storage_hwm_date: bool = typer.Option(
-        False,
+    restrict_to_permanent_storage_hwm_date: bool | None = typer.Option(
+        None,
         "--restrict-to-permanent-storage-hwm-date/--no-restrict-to-permanent-storage-hwm-date",
         help="Use PermanentStorageHwmDate guard from API for incremental export.",
     ),

--- a/src/ksef_client/cli/sdk/adapters.py
+++ b/src/ksef_client/cli/sdk/adapters.py
@@ -1606,7 +1606,7 @@ def run_export(
     date_to: str | None,
     date_type: str = m.InvoiceQueryDateType.ISSUE.value,
     subject_type: str,
-    restrict_to_permanent_storage_hwm_date: bool = False,
+    restrict_to_permanent_storage_hwm_date: bool | None = None,
     only_metadata: bool = False,
     poll_interval: float,
     max_attempts: int,
@@ -1616,6 +1616,15 @@ def run_export(
     _validate_polling_options(poll_interval, max_attempts)
     from_iso, to_iso = _normalize_date_range(date_from, date_to)
     date_type_enum = _require_invoice_query_date_type(date_type)
+    restrict_hwm = restrict_to_permanent_storage_hwm_date
+    if date_type_enum is not m.InvoiceQueryDateType.PERMANENTSTORAGE:
+        if restrict_hwm is True:
+            raise CliError(
+                "PermanentStorageHwmDate guard can only be used with PermanentStorage date type.",
+                ExitCode.VALIDATION_ERROR,
+                "Use --date-type PermanentStorage or remove the HWM guard flag.",
+            )
+        restrict_hwm = None
     out_dir = Path(out).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1636,7 +1645,7 @@ def run_export(
                     date_type=date_type_enum,
                     from_=from_iso,
                     to=to_iso,
-                    restrict_to_permanent_storage_hwm_date=restrict_to_permanent_storage_hwm_date,
+                    restrict_to_permanent_storage_hwm_date=restrict_hwm,
                 ),
             ),
         )
@@ -1699,7 +1708,7 @@ def run_export(
         "from": from_iso,
         "to": to_iso,
         "date_type": date_type_enum.value,
-        "restrict_to_permanent_storage_hwm_date": restrict_to_permanent_storage_hwm_date,
+        "restrict_to_permanent_storage_hwm_date": restrict_hwm,
     }
 
 

--- a/tests/cli/integration/test_export_run.py
+++ b/tests/cli/integration/test_export_run.py
@@ -56,6 +56,19 @@ def test_export_run_only_metadata_flag(runner, monkeypatch, tmp_path) -> None:
     assert seen["only_metadata"] is True
 
 
+def test_export_run_defaults_hwm_guard_to_none(runner, monkeypatch, tmp_path) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_run(**kwargs):
+        seen.update(kwargs)
+        return {"reference_number": "EXP-HWM-DEFAULT"}
+
+    monkeypatch.setattr(export_cmd, "run_export", _fake_run)
+    result = runner.invoke(app, ["export", "run", "--out", str(tmp_path)])
+    assert result.exit_code == 0
+    assert seen["restrict_to_permanent_storage_hwm_date"] is None
+
+
 def test_export_run_validation_error_exit(runner, monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         export_cmd,

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -2835,6 +2835,7 @@ def test_run_export_rejects_hwm_guard_for_issue_date_type(monkeypatch, tmp_path)
         )
 
     assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert exc.value.hint is not None
     assert "PermanentStorage" in exc.value.hint
 
 

--- a/tests/cli/unit/test_sdk_adapters.py
+++ b/tests/cli/unit/test_sdk_adapters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -2636,7 +2635,7 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
     assert result["metadata_count"] == 1
     assert result["only_metadata"] is False
     assert result["date_type"] == "Issue"
-    assert result["restrict_to_permanent_storage_hwm_date"] is False
+    assert result["restrict_to_permanent_storage_hwm_date"] is None
     payload = seen["payload"]
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.only_metadata is False
@@ -2644,7 +2643,8 @@ def test_run_export_success(monkeypatch, tmp_path) -> None:
     assert seen["encryption_cert"] == "CERT"
     assert seen["public_key_id"] == "key-id"
     assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.ISSUE
-    assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is False
+    assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is None
+    assert "restrictToPermanentStorageHwmDate" not in payload.filters.date_range.to_dict()
     assert (tmp_path / "_metadata.json").exists()
     assert (tmp_path / "a.xml").read_text(encoding="utf-8") == "<xml/>"
 
@@ -2741,7 +2741,7 @@ def test_run_export_only_metadata_success(monkeypatch, tmp_path) -> None:
     assert list(tmp_path.glob("*.xml")) == []
 
 
-def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
+def test_run_export_incremental_hwm_filters(monkeypatch, tmp_path) -> None:
     seen: dict[str, object] = {}
 
     class _Security:
@@ -2795,8 +2795,6 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
     monkeypatch.setattr(adapters, "ExportWorkflow", _FakeExportWorkflow)
     monkeypatch.setattr(adapters.time, "sleep", lambda _: None)
 
-    out_dir = Path("build_test_export_hwm")
-    out_dir.mkdir(parents=True, exist_ok=True)
     result = adapters.run_export(
         profile="demo",
         base_url="https://example.invalid",
@@ -2807,7 +2805,7 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
         restrict_to_permanent_storage_hwm_date=True,
         poll_interval=0.01,
         max_attempts=2,
-        out=str(out_dir),
+        out=str(tmp_path),
     )
 
     assert result["reference_number"] == "EXP-HWM"
@@ -2817,6 +2815,27 @@ def test_run_export_incremental_hwm_filters(monkeypatch) -> None:
     assert isinstance(payload, m.InvoiceExportRequest)
     assert payload.filters.date_range.date_type == m.InvoiceQueryDateType.PERMANENTSTORAGE
     assert payload.filters.date_range.restrict_to_permanent_storage_hwm_date is True
+
+
+def test_run_export_rejects_hwm_guard_for_issue_date_type(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(adapters, "get_tokens", lambda profile: ("acc", "ref"))
+
+    with pytest.raises(CliError) as exc:
+        adapters.run_export(
+            profile="demo",
+            base_url="https://example.invalid",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            date_type="Issue",
+            subject_type="Subject1",
+            restrict_to_permanent_storage_hwm_date=True,
+            poll_interval=0.01,
+            max_attempts=2,
+            out=str(tmp_path),
+        )
+
+    assert exc.value.code == ExitCode.VALIDATION_ERROR
+    assert "PermanentStorage" in exc.value.hint
 
 
 def test_export_run_cli_passes_incremental_options(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- treat the export HWM guard CLI option as tri-state so omitted flags stay `None`
- omit `restrictToPermanentStorageHwmDate` for `Issue` and `Invoicing` date ranges
- reject enabling the HWM guard unless `--date-type PermanentStorage` is used
- add regression coverage for the default CLI path and adapter payload serialization

Fixes #63

## Tests
- `.venv/bin/python -m pytest tests/cli/unit/test_sdk_adapters.py tests/cli/integration/test_export_run.py`
- `.venv/bin/python -m ruff check .`